### PR TITLE
fix: use npm ci instead of npm install in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Instalăm toate dependențele (inclusiv devDependencies pentru build)
-RUN npm install
+RUN npm ci
 
 # Copiem restul codului sursă
 COPY . .
@@ -41,7 +41,7 @@ ENV PORT=8080
 COPY package*.json ./
 
 # Instalăm DOAR dependențele de producție
-RUN npm install --omit=dev && npm cache clean --force
+RUN npm ci --omit=dev && npm cache clean --force
 
 # Copiem build-urile din stage-ul anterior
 COPY --from=builder /app/dist ./dist


### PR DESCRIPTION
## Summary
- Replace `npm install` with `npm ci` in Dockerfile
- Fixes Cloud Build error 127

## Test plan
- [ ] Cloud Build completes successfully
- [ ] Application deploys to Cloud Run
