### PR TITLE
fix: add --ignore-scripts flag to npm ci in Cloud Build

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -11,7 +11,7 @@ steps:
   # ==========================================
   - name: 'node:20'
     entrypoint: npm
-    args: ['ci']
+    args: ['ci', '--ignore-scripts']
     id: 'install'
 
   # ==========================================


### PR DESCRIPTION
The npm ci command in cloudbuild.yaml was failing with exit code 127 because it tried to run the 'prepare' script which executes 'husky'. The husky command is not available in the Cloud Build node:20 container.

This fix adds --ignore-scripts flag to prevent lifecycle scripts from running during dependency installation, matching the approach already used in the Dockerfile.

Fixes the Docker build failure in Cloud Build (npm ci exit 127).