### PR TITLE
feat(xp): fix XP display consistency and add streak bonus

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,6 +14,7 @@ import { MOCK_DECKS, MOCK_ACHIEVEMENTS, LEADERBOARD_DATA } from './constants';
 import { Deck, Card, SessionData } from './types';
 import { Menu, X, Loader2 } from 'lucide-react';
 import * as decksApi from './src/api/decks';
+import * as usersApi from './src/api/users';
 
 // Guest user for freemium mode
 const GUEST_USER = {
@@ -85,7 +86,13 @@ function adaptDeckFromAPI(apiDeck: any): Deck {
 
 // Main app content
 function AppContent() {
-  const { isAuthenticated, isLoading: authLoading, user: authUser, logout } = useAuth();
+  const {
+    isAuthenticated,
+    isLoading: authLoading,
+    user: authUser,
+    logout,
+    refreshSession,
+  } = useAuth();
 
   const [currentView, setCurrentView] = useState('dashboard');
   const [activeDeck, setActiveDeck] = useState<Deck | null>(null);
@@ -211,9 +218,19 @@ function AppContent() {
     }
   };
 
-  const handleUpdateUserXP = (newXP: number) => {
+  const handleUpdateUserXP = async (deltaXP: number) => {
     if (isGuest) return; // Don't update XP for guests
-    console.log('Update XP:', newXP);
+    if (!authUser) return;
+
+    try {
+      const response = await usersApi.updateUserXP(authUser.id, deltaXP);
+      if (response.success && response.data) {
+        // Refresh the user session to get updated XP
+        await refreshSession();
+      }
+    } catch (error) {
+      console.error('Error updating XP:', error);
+    }
   };
 
   const handleAddDeck = async (newDeck: Deck) => {

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -1,0 +1,21 @@
+import { api } from './client';
+import type { User } from '../types';
+
+export interface UpdateXPRequest {
+  deltaXP: number;
+}
+
+export async function updateUserXP(userId: string, deltaXP: number) {
+  return api.post<User>(`/users/${userId}/xp`, { deltaXP });
+}
+
+export async function getUserProfile(userId: string) {
+  return api.get<User>(`/users/${userId}`);
+}
+
+export async function updateUserProfile(
+  userId: string,
+  data: { name?: string; avatar?: string; preferences?: any }
+) {
+  return api.put<User>(`/users/${userId}`, data);
+}


### PR DESCRIPTION
Fixes multiple XP-related issues:

1. **Fix hint XP verification**: Now checks available XP (user.currentXP + sessionXP) instead of just user.currentXP, preventing false "insufficient XP" errors

2. **Add 50 XP bonus for 5-streak**: Award bonus 50 XP for every 5 consecutive correct answers with toast notification

3. **Create XP update endpoint**: New POST /api/users/:id/xp endpoint that:
   - Accepts deltaXP (positive or negative)
   - Handles level-up logic automatically
   - Updates current_xp, total_xp, level, and next_level_xp

4. **Implement XP sync**: Session XP now syncs to backend when:
   - Using hints (deducts from session XP first, then user XP)
   - Finishing study session (syncs accumulated session XP)

5. **Fix handleUpdateUserXP**: Now makes real API call to update XP and refreshes user session from AuthContext

Files changed:
- App.tsx: Import users API, fix handleUpdateUserXP with API call
- components/StudySession.tsx: Fix hint verification, add streak bonus, sync XP on finish
- server/routes/users.ts: Add POST /api/users/:id/xp endpoint with level-up logic
- src/api/users.ts: New file with updateUserXP, getUserProfile, updateUserProfile functions

Related to TODO.md P1 priority: Fix XP display consistency