### PR TITLE
fix: resolve navigation bugs, modal issues, and standardize UI hierarchy

### DIFF
--- a/components/DeckList.tsx
+++ b/components/DeckList.tsx
@@ -381,7 +381,7 @@ const DeckList: React.FC<DeckListProps> = ({
               key={deck.id}
               className="bg-[#F8F6F1] p-6 rounded-3xl relative group hover:shadow-md transition-shadow flex flex-col"
             >
-              {/* Delete Menu (top-right corner) */}
+              {/* Three-Dot Menu (top-right corner) */}
               <div className="absolute top-4 right-4">
                 <div className="relative">
                   <button
@@ -392,12 +392,54 @@ const DeckList: React.FC<DeckListProps> = ({
                   </button>
 
                   {activeMenuId === deck.id && (
-                    <div className="absolute right-0 top-8 bg-white shadow-xl rounded-xl p-2 min-w-[140px] z-10 border border-gray-100 animate-fade-in">
+                    <div className="absolute right-0 top-8 bg-white shadow-xl rounded-xl p-2 min-w-[180px] z-10 border border-gray-100 animate-fade-in">
+                      {/* Resetează progresul - Only show if has progress */}
+                      {hasProgress && onResetDeck && deck.totalCards > 0 && (
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            onResetDeck(deck.id);
+                            setActiveMenuId(null);
+                          }}
+                          className="w-full text-left px-3 py-2 text-sm text-orange-600 hover:bg-orange-50 rounded-lg flex items-center gap-2 font-medium"
+                        >
+                          <RotateCcw size={16} /> Resetează progresul
+                        </button>
+                      )}
+                      {/* Editează deck */}
                       <button
-                        onClick={() => onDeleteDeck(deck.id)}
-                        className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg flex items-center gap-2 font-medium"
+                        onClick={e => {
+                          e.stopPropagation();
+                          openEditModal(deck);
+                        }}
+                        className="w-full text-left px-3 py-2 text-sm text-indigo-600 hover:bg-indigo-50 rounded-lg flex items-center gap-2 font-medium"
                       >
-                        <Trash2 size={16} /> Șterge
+                        <Edit size={16} /> Editează deck
+                      </button>
+                      {/* Editează carduri - Only show if has cards */}
+                      {deck.cards && deck.cards.length > 0 && (
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            openEditCardsModal(deck);
+                          }}
+                          className="w-full text-left px-3 py-2 text-sm text-blue-600 hover:bg-blue-50 rounded-lg flex items-center gap-2 font-medium"
+                        >
+                          <List size={16} /> Editează carduri
+                        </button>
+                      )}
+                      {/* Șterge deck with confirmation */}
+                      <button
+                        onClick={e => {
+                          e.stopPropagation();
+                          if (confirm(`Sigur vrei să ștergi deck-ul "${deck.title}"?`)) {
+                            onDeleteDeck(deck.id);
+                          }
+                          setActiveMenuId(null);
+                        }}
+                        className="w-full text-left px-3 py-2 text-sm text-red-600 hover:bg-red-50 rounded-lg flex items-center gap-2 font-medium border-t border-gray-100 mt-1 pt-2"
+                      >
+                        <Trash2 size={16} /> Șterge deck
                       </button>
                     </div>
                   )}
@@ -452,37 +494,7 @@ const DeckList: React.FC<DeckListProps> = ({
 
               {/* Permanent Action Bar */}
               <div className="flex gap-2 mt-auto">
-                {/* 1. Reset Progress - Visible only if progress > 0% */}
-                {hasProgress && onResetDeck && deck.totalCards > 0 && (
-                  <button
-                    onClick={e => {
-                      e.stopPropagation();
-                      onResetDeck(deck.id);
-                    }}
-                    className="p-3 border-2 border-gray-200 text-gray-600 rounded-xl hover:border-red-200 hover:text-red-600 hover:bg-red-50 transition-colors"
-                    title="Resetează progresul"
-                  >
-                    <RotateCcw size={18} />
-                  </button>
-                )}
-
-                {/* 2. Modify - Icon only, permanent */}
-                <button
-                  onClick={e => {
-                    e.stopPropagation();
-                    if (deck.cards && deck.cards.length > 0) {
-                      openEditCardsModal(deck);
-                    } else {
-                      openEditModal(deck);
-                    }
-                  }}
-                  className="p-3 border-2 border-gray-200 text-gray-600 rounded-xl hover:border-indigo-200 hover:text-indigo-600 hover:bg-indigo-50 transition-colors"
-                  title="Modifică"
-                >
-                  <Edit size={18} />
-                </button>
-
-                {/* 3. Generate Cards - Permanent */}
+                {/* 1. Generate Cards */}
                 <button
                   onClick={e => {
                     e.stopPropagation();
@@ -494,13 +506,13 @@ const DeckList: React.FC<DeckListProps> = ({
                   <Sparkles size={18} /> Generează
                 </button>
 
-                {/* 4. Create Session - Re-labeled from "Studiază" */}
+                {/* 2. Create Session */}
                 <button
                   onClick={e => {
                     e.stopPropagation();
                     onStartSession(deck);
                   }}
-                  className="flex-1 bg-gray-900 hover:bg-gray-800 text-white font-bold py-3 px-4 rounded-xl transition-all flex items-center justify-center gap-2 text-sm"
+                  className="flex-1 bg-gray-900 hover:bg-gray-800 text-white font-bold py-3 px-4 rounded-xl transition-all flex items-center justify-center gap-2 text-sm disabled:opacity-50 disabled:cursor-not-allowed"
                   disabled={!deck.cards || deck.cards.length === 0}
                   title={
                     deck.cards && deck.cards.length > 0
@@ -519,7 +531,7 @@ const DeckList: React.FC<DeckListProps> = ({
       {/* Modal for New/Edit Deck (Code omitted for brevity as it's identical to previous, just wrapped in same component) */}
       {isModalOpen && (
         <div className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4 backdrop-blur-sm">
-          <div className="bg-white rounded-3xl w-full max-w-md p-8 shadow-2xl animate-scale-up">
+          <div className="bg-white rounded-3xl w-full max-w-md max-h-[90vh] overflow-y-auto p-8 shadow-2xl animate-scale-up">
             <h2 className="text-2xl font-bold mb-6 text-gray-900">
               {editingDeckId
                 ? 'Editează Deck'

--- a/components/StudySession.tsx
+++ b/components/StudySession.tsx
@@ -251,9 +251,14 @@ const StudySession: React.FC<StudySessionProps> = ({
       onUpdateUserXP(-remainingCost);
     }
 
-    // Reveal Hint
+    // Reveal Hint and auto-hide after 5 seconds
     setHintRevealed(true);
     toast.info('Indiciu folosit', `-${COST} XP`);
+
+    // Auto-hide hint after 5 seconds
+    setTimeout(() => {
+      setHintRevealed(false);
+    }, 5000);
   };
 
   // Helper to render context with bold word
@@ -1010,52 +1015,56 @@ const StudySession: React.FC<StudySessionProps> = ({
                   </div>
                 )}
 
-                {/* Navigation and Flip buttons at bottom of card - ONLY for standard cards */}
-                {!isFlipped && currentCard.type === 'standard' && (
-                  <div className="absolute bottom-6 left-0 right-0 px-6 z-50">
-                    <div className="flex items-center gap-3">
-                      {/* Back Button */}
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          goToPrevious();
-                        }}
-                        disabled={currentIndex === 0}
-                        className="w-12 h-12 flex items-center justify-center rounded-xl bg-white border-2 border-gray-200 text-gray-600 shadow-sm hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed transition-all active:scale-95"
-                        title="Card anterior"
-                      >
-                        <ChevronLeft size={20} />
-                      </button>
+                {/* Navigation and Control buttons at bottom of card - for standard and type-answer cards */}
+                {!isFlipped &&
+                  (currentCard.type === 'standard' || currentCard.type === 'type-answer') && (
+                    <div className="absolute bottom-6 left-0 right-0 px-6 z-50">
+                      <div className="flex items-center gap-3">
+                        {/* Back Button */}
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            goToPrevious();
+                          }}
+                          disabled={currentIndex === 0}
+                          className="w-12 h-12 flex items-center justify-center rounded-xl bg-white border-2 border-gray-200 text-gray-600 shadow-sm hover:bg-gray-50 disabled:opacity-30 disabled:cursor-not-allowed transition-all active:scale-95"
+                          title="Înapoi"
+                        >
+                          <ChevronLeft size={20} />
+                        </button>
 
-                      {/* Show Answer Button */}
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          handleFlip();
-                        }}
-                        className="flex-1 bg-indigo-600 text-white font-bold py-3 rounded-xl shadow-md hover:bg-indigo-700 active:bg-indigo-800 transition-all active:scale-98"
-                      >
-                        Arată Răspunsul
-                      </button>
+                        {/* Show Answer Button - For standard cards OR when user hasn't typed answer in type-answer */}
+                        {currentCard.type === 'standard' ||
+                        (currentCard.type === 'type-answer' && !userInputValue.trim()) ? (
+                          <button
+                            onClick={e => {
+                              e.stopPropagation();
+                              handleFlip();
+                            }}
+                            className="flex-1 bg-indigo-600 text-white font-bold py-3 rounded-xl shadow-md hover:bg-indigo-700 active:bg-indigo-800 transition-all active:scale-98"
+                          >
+                            Afișează răspunsul
+                          </button>
+                        ) : null}
 
-                      {/* Next Button */}
-                      <button
-                        onClick={e => {
-                          e.stopPropagation();
-                          handleSkip();
-                        }}
-                        className="w-12 h-12 flex items-center justify-center rounded-xl bg-white border-2 border-gray-200 text-gray-600 shadow-sm hover:bg-gray-50 transition-all active:scale-95"
-                        title="Card următor"
-                      >
-                        {currentIndex === activeCards.length - 1 ? (
-                          <CheckCircle size={20} className="text-indigo-600" />
-                        ) : (
-                          <ArrowRight size={20} />
-                        )}
-                      </button>
+                        {/* Forward Button (Skip) */}
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            handleSkip();
+                          }}
+                          className="w-12 h-12 flex items-center justify-center rounded-xl bg-white border-2 border-gray-200 text-gray-600 shadow-sm hover:bg-gray-50 transition-all active:scale-95"
+                          title="Înainte"
+                        >
+                          {currentIndex === activeCards.length - 1 ? (
+                            <CheckCircle size={20} className="text-indigo-600" />
+                          ) : (
+                            <ArrowRight size={20} />
+                          )}
+                        </button>
+                      </div>
                     </div>
-                  </div>
-                )}
+                  )}
               </div>
 
               {/* BACK */}


### PR DESCRIPTION
BREAKING CHANGES:
- My Decks Page: Moved "Resetează progresul", "Editează deck", and "Editează carduri" buttons into three-dot menu
- Active Sessions Page: Restructured tile hierarchy with Category+Topic in Row 1, metadata in Row 2

FIXES:

A. My Decks Page (Deck-urile Mele):
- Moved "Resetează progresul" from tile footer to three-dot menu (conditional)
- Moved "Editează deck" to three-dot menu
- Added "Editează carduri" to three-dot menu (opens CRUD modal)
- Kept "Șterge deck" in menu with mandatory confirmation modal
- Added scrollbar (max-h-[90vh] overflow-y-auto) to "Deck Nou" modal for smaller screens
- Simplified action bar to only show "Generează" and "Creează sesiune" buttons

B. Active Sessions Page (Sesiuni Active):
- Updated subtitle from "sesiuni în desfășurare" to "sesiuni de învățare în desfășurare"
- Restructured tile visual hierarchy:
  * Row 1 (H3): Category (e.g., Limba Română) + Topic (e.g., Sinonime)
  * Row 2: Metadata: [x] carduri | [Method with icon]
- Moved delete action to top-right three-dot menu with confirmation modal
- Changed "Continuă" button to full-width layout after removing trash icon

C. Study Session Page (Session Interface):
- Fixed "Show Answer" button visibility for type-answer cards
- Button now shows for both standard and type-answer cards (when no input typed)
- Added auto-hide timer (5 seconds) for hint reveal
- Improved button titles and labels ("Înapoi", "Înainte", "Afișează răspunsul")
- Fixed skip logic to properly mark cards as "Skipped" with visible badge

Technical Notes:
- All changes maintain backward compatibility with existing data structures
- State management unchanged - only UI/UX improvements
- Added MoreVertical import to ActiveSessionsList component
- Cleaned up duplicate Time & Method info section in Active Sessions
- Improved responsive design with proper button states and tooltips