### PR TITLE
feat(visitor): comprehensive visitor mode refactoring and bug fixes

### DIFF
--- a/components/DeckList.tsx
+++ b/components/DeckList.tsx
@@ -31,6 +31,8 @@ interface DeckListProps {
   onDeleteDeck: (deckId: string) => void;
   onStartSession: (deck: Deck) => void;
   onResetDeck?: (deckId: string) => void;
+  isGuest?: boolean;
+  onLoginPrompt?: (title: string, message: string) => void;
 }
 
 const DeckList: React.FC<DeckListProps> = ({
@@ -40,6 +42,8 @@ const DeckList: React.FC<DeckListProps> = ({
   onDeleteDeck,
   onStartSession,
   onResetDeck,
+  isGuest = false,
+  onLoginPrompt,
 }) => {
   const toast = useToast();
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -100,6 +104,15 @@ const DeckList: React.FC<DeckListProps> = ({
   }, [isGenerating, dealerMessages.length]);
 
   const openCreateModal = () => {
+    // Guard: Visitors must register to create decks
+    if (isGuest && onLoginPrompt) {
+      onLoginPrompt(
+        'Creează un cont gratuit',
+        'Pentru a crea propriile deck-uri și a le salva permanent, creează un cont gratuit!'
+      );
+      return;
+    }
+
     setEditingDeckId(null);
     setGeneratingForDeckId(null);
     setTitle('');
@@ -122,6 +135,15 @@ const DeckList: React.FC<DeckListProps> = ({
   };
 
   const openGenerateCardsModal = (deck: Deck) => {
+    // Guard: Visitors must register to use AI generation
+    if (isGuest && onLoginPrompt) {
+      onLoginPrompt(
+        'Funcție Premium',
+        'Generarea de carduri cu AI este disponibilă doar pentru utilizatorii cu cont. Creează un cont gratuit pentru a debloca această funcție!'
+      );
+      return;
+    }
+
     setEditingDeckId(null);
     setGeneratingForDeckId(deck.id);
     setTitle(deck.title || '');

--- a/components/Leaderboard.tsx
+++ b/components/Leaderboard.tsx
@@ -5,9 +5,11 @@ import { Flame, Medal, Users } from 'lucide-react';
 interface LeaderboardProps {
   entries: LeaderboardEntry[];
   currentUser?: User;
+  onRegisterClick?: () => void;
 }
 
-const Leaderboard: React.FC<LeaderboardProps> = ({ entries, currentUser }) => {
+const Leaderboard: React.FC<LeaderboardProps> = ({ entries, currentUser, onRegisterClick }) => {
+  const isVisitor = currentUser?.id === 'guest';
   // Find current user in entries or create from currentUser prop
   const currentUserEntry = useMemo(() => {
     const fromEntries = entries.find(e => e.isCurrentUser);
@@ -94,9 +96,18 @@ const Leaderboard: React.FC<LeaderboardProps> = ({ entries, currentUser }) => {
         <div className="bg-[#F8F6F1] p-6 rounded-2xl flex flex-col items-center justify-center text-center">
           <h3 className="text-gray-500 mb-2">Poziția Ta</h3>
           <div className="text-4xl font-bold text-gray-900">{userStats.position}</div>
-          <p className="text-xs text-gray-400 mt-1">
-            din {userStats.totalUsers.toLocaleString()} utilizatori
-          </p>
+          {isVisitor ? (
+            <button
+              onClick={onRegisterClick}
+              className="text-xs text-indigo-600 font-bold mt-2 hover:text-indigo-700 transition-colors"
+            >
+              Înregistrează-te pentru a apărea în clasament
+            </button>
+          ) : (
+            <p className="text-xs text-gray-400 mt-1">
+              din {userStats.totalUsers.toLocaleString()} utilizatori
+            </p>
+          )}
         </div>
         <div className="bg-[#F8F6F1] p-6 rounded-2xl flex flex-col items-center justify-center text-center">
           <h3 className="text-gray-500 mb-2">XP Total</h3>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -21,6 +21,7 @@ interface SidebarProps {
   onCloseMobile: () => void;
   isGuest?: boolean;
   onLoginClick?: () => void;
+  onRegisterClick?: () => void;
 }
 
 const Sidebar: React.FC<SidebarProps> = ({
@@ -31,6 +32,7 @@ const Sidebar: React.FC<SidebarProps> = ({
   onCloseMobile,
   isGuest = false,
   onLoginClick,
+  onRegisterClick,
 }) => {
   const xpPercentage = Math.min((user.currentXP / user.nextLevelXP) * 100, 100);
 
@@ -105,17 +107,25 @@ const Sidebar: React.FC<SidebarProps> = ({
         )}
 
         {/* Guest CTA */}
-        {isGuest && onLoginClick && (
-          <div className="mb-6 bg-gradient-to-br from-gray-900 to-gray-800 rounded-xl p-4 text-white">
-            <p className="text-sm opacity-90 mb-3">
-              Creează un cont pentru a salva progresul și a debloca toate funcționalitățile!
+        {isGuest && onRegisterClick && onLoginClick && (
+          <div className="mb-6 bg-gradient-to-br from-gray-900 to-gray-800 rounded-xl p-4 text-white space-y-3">
+            <p className="text-sm opacity-90">
+              Creează un cont <span className="font-bold">gratuit</span> pentru a salva progresul și
+              a debloca funcții avansate!
             </p>
             <button
-              onClick={onLoginClick}
+              onClick={onRegisterClick}
               className="w-full bg-white text-gray-900 font-bold py-2 px-4 rounded-lg hover:bg-gray-100 transition-colors flex items-center justify-center gap-2"
             >
               <UserPlus size={18} />
-              Creează cont gratuit
+              Cont nou
+            </button>
+            <button
+              onClick={onLoginClick}
+              className="w-full bg-transparent text-white font-bold py-2 px-4 rounded-lg border-2 border-white/30 hover:bg-white/10 transition-colors flex items-center justify-center gap-2"
+            >
+              <LogIn size={18} />
+              Autentificare
             </button>
           </div>
         )}
@@ -140,17 +150,6 @@ const Sidebar: React.FC<SidebarProps> = ({
             </button>
           ))}
         </nav>
-
-        {/* Login button for guests */}
-        {isGuest && onLoginClick && (
-          <button
-            onClick={onLoginClick}
-            className="flex items-center gap-3 px-4 py-3 text-gray-600 hover:text-gray-900 hover:bg-[#EFECE5] rounded-xl transition-colors mt-auto"
-          >
-            <LogIn size={20} />
-            <span>Autentificare</span>
-          </button>
-        )}
       </div>
     </div>
   );

--- a/constants.ts
+++ b/constants.ts
@@ -394,6 +394,16 @@ export const MOCK_DECKS: (Deck & {
   },
 ];
 
+// Demo deck for visitors (only Sinonime)
+export const DEMO_DECK = MOCK_DECKS[0]; // Sinonime Esențiale
+export const VISITOR_DECKS = [DEMO_DECK];
+
+// Visitor achievements (all locked for demo purposes)
+export const VISITOR_ACHIEVEMENTS: Achievement[] = MOCK_ACHIEVEMENTS.map(achievement => ({
+  ...achievement,
+  unlocked: false,
+}));
+
 export const LEADERBOARD_DATA: LeaderboardEntry[] = [
   {
     id: 'l1',

--- a/src/components/auth/AuthPage.tsx
+++ b/src/components/auth/AuthPage.tsx
@@ -2,8 +2,12 @@ import React, { useState } from 'react';
 import Login from './Login';
 import Register from './Register';
 
-const AuthPage: React.FC = () => {
-  const [isLogin, setIsLogin] = useState(true);
+interface AuthPageProps {
+  initialMode?: 'login' | 'register';
+}
+
+const AuthPage: React.FC<AuthPageProps> = ({ initialMode = 'login' }) => {
+  const [isLogin, setIsLogin] = useState(initialMode === 'login');
 
   return isLogin ? (
     <Login onSwitchToRegister={() => setIsLogin(false)} />


### PR DESCRIPTION
This commit stabilizes the visitor (unauthenticated) experience by fixing critical bugs and aligning the UI/UX with product requirements.

Backend Changes:
- Fix infinite 401 loop on public decks API route
  * Change GET /api/decks from authenticateToken to optionalAuth
  * Allow unauthenticated access when publicOnly=true parameter is present
  * Update SQL queries to handle null user context for visitors
  * Add review rating aggregation (averageRating, reviewCount) to deck responses

Frontend Changes - Data & Constants:
- Filter demo content for visitors
  * Add VISITOR_DECKS constant (only "Sinonime Esențiale" demo deck)
  * Add VISITOR_ACHIEVEMENTS constant (all achievements locked)
  * Replace MOCK_DECKS with VISITOR_DECKS for guest users

Frontend Changes - Authentication Flow:
- Enhance auth mode switching
  * Add authMode state to App.tsx (login | register)
  * Add handleRegisterClick handler for direct sign-up flow
  * Update AuthPage to accept initialMode prop
  * Differentiate between Login and Register entry points

Frontend Changes - Sidebar UI/UX:
- Redesign visitor prompt and buttons
  * Update text to emphasize "gratuit" and "funcții avansate"
  * Change "Creează cont gratuit" button to "Cont nou"
  * Add "Autentificare" button in CTA card below "Cont nou"
  * Remove redundant "Autentificare" button from sidebar bottom
  * Add onRegisterClick prop to Sidebar component

Frontend Changes - Achievements:
- Fix visitor achievements display
  * Show 0 unlocked badges for visitors (was showing 4)
  * Conditionally render VISITOR_ACHIEVEMENTS vs MOCK_ACHIEVEMENTS

Frontend Changes - Leaderboard:
- Enable real API data for visitors
  * Fetch global leaderboard from API for all users (not just authenticated)
  * Add isVisitor detection and onRegisterClick prop to Leaderboard
  * Show CTA "Înregistrează-te pentru a apărea în clasament" for visitors
  * Replace mock data with real API data for unauthenticated users

Frontend Changes - Access Control:
- Add registration guardrails for premium features
  * Block "Generează" (AI generation) button for visitors
  * Block "Deck Nou" (create deck) button for visitors
  * Show LoginPromptModal with appropriate messaging
  * Add isGuest and onLoginPrompt props to DeckList

QA Checklist:
✅ No 401 errors when visitor clicks "Deck-uri Globale" ✅ Demo deck "Sinonime" works for visitor study sessions ✅ "Cont nou" in sidebar opens Sign Up; "Autentificare" opens Login ✅ Achievements show 0 unlocked badges for visitors ✅ AI Generate and New Deck buttons blocked for visitors with registration prompt

Fixes #[issue-number]