### PR TITLE
fix(visitor): resolve critical visitor experience blockers

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -281,7 +281,15 @@ function AppContent() {
   // --- ACTIONS ---
 
   const handleStartSession = (deck: Deck) => {
-    // Use new session architecture
+    // Allow visitors to study the demo deck using legacy StudySession
+    if (isGuest && deck.id === 'd1') {
+      // Use old study session flow for demo deck
+      setActiveDeck(deck);
+      setCurrentView('study');
+      return;
+    }
+
+    // Use new session architecture for authenticated users
     handleCreateSession(deck);
   };
 


### PR DESCRIPTION
Fixes two critical bugs preventing visitor functionality:

1. Fix 500 Internal Server Error on Global Decks API
   - Issue: SQL parameter mismatch when userId is null for visitors
   - Root cause: Template literals with $${paramIndex} but missing params in array
   - Solution: Rebuild query params array explicitly before/after userId checks
   - Location: server/routes/decks.ts:94-145

   Technical details:
   - Create separate decksParams array and deckParamIndex counter
   - Conditionally add userId params only if authenticated
   - Ensure LIMIT/OFFSET params always at correct positions
   - Result: Visitors can now browse public decks without 401/500 errors

2. Enable demo deck study sessions for visitors
   - Issue: "Creează sesiune" button blocked all visitors with login modal
   - Root cause: handleStartSession unconditionally required authentication
   - Solution: Allow demo deck (id='d1') to use legacy StudySession.tsx
   - Location: App.tsx:283-294

   Flow logic:
   - IF visitor AND demo deck → use old study flow (no persistence)
   - ELSE → use new session architecture (requires auth)
   - Visitors can now test core study functionality with Sinonime deck

Testing:
- ✅ Visitors can browse "Deck-uri Globale" without errors
- ✅ Visitors can click "Creează sesiune" on demo deck and study
- ✅ Authenticated users continue using new session architecture
- ✅ No regression in existing deck management flows

Refs #[issue-number]