### PR TITLE
fix: CreateSessionModal slider - pass complete deck data with totalCards

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -23,7 +23,7 @@ import { clearGuestToken } from './src/utils/guestMode';
 function AppContent() {
   const { t } = useTranslation();
   const { isAuthenticated, isLoading: authLoading } = useAuth();
-  const { fetchDecks } = useDecksStore();
+  const { fetchDecks, decks } = useDecksStore();
   const {
     showAuthPage,
     showLoginPrompt,
@@ -86,15 +86,24 @@ function AppContent() {
     );
   }
 
+  // Find the selected deck for the modal
+  const selectedDeck = selectedDeckForSession
+    ? decks.find(d => d.id === selectedDeckForSession)
+    : null;
+
   // Main app
   return (
     <AppLayout>
       <ViewRouter />
 
       {/* Modals */}
-      {showCreateSessionModal && selectedDeckForSession && (
+      {showCreateSessionModal && selectedDeck && (
         <CreateSessionModal
-          deck={{ id: selectedDeckForSession } as any}
+          deck={{
+            id: selectedDeck.id,
+            title: selectedDeck.title,
+            totalCards: selectedDeck.totalCards,
+          }}
           onClose={() => setShowCreateSessionModal(false)}
           onSessionCreated={handleSessionCreated}
         />


### PR DESCRIPTION
ROOT CAUSE:
App.tsx was passing an incomplete deck object to CreateSessionModal:
  deck={{ id: selectedDeckForSession } as any}
This object only had the 'id' property, missing:
  - totalCards (needed for slider max value)
  - title (needed for display)

SYMPTOMS:
1. Slider shows 0 cards on the right side (should show total)
2. User cannot move the slider cursor (max is 0)
3. "0 available" displays below slider
4. Session creation fails with "Deck-ul nu conține carduri" error

THE FIX:
1. Get 'decks' from useDecksStore in App.tsx
2. Find the selected deck from the decks array
3. Pass complete deck object with:
   - id: selectedDeck.id
   - title: selectedDeck.title
   - totalCards: selectedDeck.totalCards

HOW IT WORKS:
- When user clicks "Start Session", handleStartSession(deck) is called
- This calls setShowCreateSessionModal(true, deck.id)
- App.tsx now finds the full deck object from the decks store
- CreateSessionModal receives proper deck data
- availableCards = deck.totalCards (not 0)
- Slider max = Math.max(5, Math.min(50, availableCards)) works correctly
- Session creation succeeds with proper cardCount

FILES MODIFIED:
- App.tsx: Added decks from useDecksStore, find deck by ID, pass complete object

TypeScript verification: 0 application errors