### PR TITLE
refactor(decks): extract modals and add export functionality

### DIFF
--- a/public/locales/en/decks.json
+++ b/public/locales/en/decks.json
@@ -16,6 +16,7 @@
     "resetProgress": "Reset progress",
     "editDeck": "Edit deck",
     "editCards": "Edit cards",
+    "exportDeck": "Export cards",
     "leaveReview": "Leave a review",
     "reportDeck": "Report deck",
     "deleteDeck": "Delete deck",
@@ -54,6 +55,10 @@
     "typeAnswerDesc": "Write the answer (suitable for 1-2 words)",
     "deselectCardType": "Deselect unwanted card type",
     "fileImport": "Supported format: CSV, TXT (Front, Back)",
+    "fileSelected": "Selected: {{name}}",
+    "importFormatTitle": "Supported Formats",
+    "importFormatCSV": "Front,Back,Context (comma-separated)",
+    "importFormatTXT": "Front[TAB]Back[TAB]Context (tab or semicolon-separated)",
     "cancel": "Cancel",
     "save": "Save",
     "generateCardsBtn": "Generate Cards",
@@ -91,6 +96,18 @@
   "loading": {
     "message": "Generating cards..."
   },
+  "exportModal": {
+    "title": "Export Cards",
+    "subtitle": "Export \"{{title}}\"",
+    "selectFormat": "Select Format",
+    "csvDesc": "Spreadsheet compatible",
+    "txtDesc": "Tab-separated text",
+    "includeProgress": "Include progress data",
+    "includeProgressDesc": "Export learning status, intervals and ease factors",
+    "previewTitle": "Format Preview",
+    "previewNote": "This is how your exported file will look",
+    "exportBtn": "Export"
+  },
   "toast": {
     "cardUpdated": "Card updated successfully",
     "cardUpdateError": "Error updating card",
@@ -99,7 +116,12 @@
     "cardAdded": "Card added successfully",
     "cardAddError": "Error adding card",
     "cardLoadError": "Error loading cards",
-    "generationError": "AI generation error. Check console."
+    "generationError": "AI generation error. Check console.",
+    "exportSuccess": "Exported {{count}} cards successfully",
+    "exportError": "Error exporting cards",
+    "importSuccess": "Imported {{count}} cards successfully",
+    "importError": "Error importing cards",
+    "fileReadError": "Error reading file"
   },
   "guestPrompt": {
     "createDeck": {

--- a/public/locales/it/decks.json
+++ b/public/locales/it/decks.json
@@ -16,6 +16,7 @@
     "resetProgress": "Ripristina progresso",
     "editDeck": "Modifica mazzo",
     "editCards": "Modifica carte",
+    "exportDeck": "Esporta carte",
     "leaveReview": "Lascia una recensione",
     "reportDeck": "Segnala mazzo",
     "deleteDeck": "Elimina mazzo",
@@ -54,6 +55,10 @@
     "typeAnswerDesc": "Scrivi la risposta (adatto per 1-2 parole)",
     "deselectCardType": "Deseleziona il tipo di carta non desiderato",
     "fileImport": "Formato supportato: CSV, TXT (Fronte, Retro)",
+    "fileSelected": "Selezionato: {{name}}",
+    "importFormatTitle": "Formati Supportati",
+    "importFormatCSV": "Fronte,Retro,Contesto (separati da virgola)",
+    "importFormatTXT": "Fronte[TAB]Retro[TAB]Contesto (separati da tab o punto e virgola)",
     "cancel": "Annulla",
     "save": "Salva",
     "generateCardsBtn": "Genera Carte",
@@ -91,6 +96,18 @@
   "loading": {
     "message": "Generazione carte in corso..."
   },
+  "exportModal": {
+    "title": "Esporta Carte",
+    "subtitle": "Esporta \"{{title}}\"",
+    "selectFormat": "Seleziona Formato",
+    "csvDesc": "Compatibile con Excel",
+    "txtDesc": "Testo separato da tab",
+    "includeProgress": "Includi dati di progresso",
+    "includeProgressDesc": "Esporta stato di apprendimento, intervalli e fattori di difficoltà",
+    "previewTitle": "Anteprima Formato",
+    "previewNote": "Ecco come apparirà il tuo file esportato",
+    "exportBtn": "Esporta"
+  },
   "toast": {
     "cardUpdated": "Carta aggiornata con successo",
     "cardUpdateError": "Errore nell'aggiornamento della carta",
@@ -99,7 +116,12 @@
     "cardAdded": "Carta aggiunta con successo",
     "cardAddError": "Errore nell'aggiunta della carta",
     "cardLoadError": "Errore nel caricamento delle carte",
-    "generationError": "Errore di generazione AI. Controlla la console."
+    "generationError": "Errore di generazione AI. Controlla la console.",
+    "exportSuccess": "{{count}} carte esportate con successo",
+    "exportError": "Errore nell'esportazione delle carte",
+    "importSuccess": "{{count}} carte importate con successo",
+    "importError": "Errore nell'importazione delle carte",
+    "fileReadError": "Errore nella lettura del file"
   },
   "guestPrompt": {
     "createDeck": {

--- a/public/locales/ro/decks.json
+++ b/public/locales/ro/decks.json
@@ -16,6 +16,7 @@
     "resetProgress": "Resetează progresul",
     "editDeck": "Editează deck",
     "editCards": "Editează carduri",
+    "exportDeck": "Exportă carduri",
     "leaveReview": "Lasă o recenzie",
     "reportDeck": "Raportează deck",
     "deleteDeck": "Șterge deck",
@@ -54,6 +55,10 @@
     "typeAnswerDesc": "Scrie răspunsul (potrivit pentru 1-2 cuvinte)",
     "deselectCardType": "Deselectează tipul de card nedorit",
     "fileImport": "Format suportat: CSV, TXT (Front, Back)",
+    "fileSelected": "Selectat: {{name}}",
+    "importFormatTitle": "Formate Suportate",
+    "importFormatCSV": "Front,Back,Context (separate prin virgulă)",
+    "importFormatTXT": "Front[TAB]Back[TAB]Context (separate prin tab sau punct și virgulă)",
     "cancel": "Anulează",
     "save": "Salvează",
     "generateCardsBtn": "Generează Carduri",
@@ -102,6 +107,18 @@
       "Dealerul AI calculează cotele. Ai șanse 100% să devii mai deștept."
     ]
   },
+  "exportModal": {
+    "title": "Exportă Carduri",
+    "subtitle": "Exportă \"{{title}}\"",
+    "selectFormat": "Selectează Format",
+    "csvDesc": "Compatibil cu Excel",
+    "txtDesc": "Text separat cu tab",
+    "includeProgress": "Include datele de progres",
+    "includeProgressDesc": "Exportă starea învățării, intervalele și factorii de dificultate",
+    "previewTitle": "Previzualizare Format",
+    "previewNote": "Așa va arăta fișierul tău exportat",
+    "exportBtn": "Exportă"
+  },
   "toast": {
     "cardUpdated": "Card actualizat cu succes",
     "cardUpdateError": "Eroare la actualizarea cardului",
@@ -110,7 +127,12 @@
     "cardAdded": "Card adăugat cu succes",
     "cardAddError": "Eroare la adăugarea cardului",
     "cardLoadError": "Eroare la încărcarea cardurilor",
-    "generationError": "Eroare la generarea AI. Verifică consola."
+    "generationError": "Eroare la generarea AI. Verifică consola.",
+    "exportSuccess": "{{count}} carduri exportate cu succes",
+    "exportError": "Eroare la exportarea cardurilor",
+    "importSuccess": "{{count}} carduri importate cu succes",
+    "importError": "Eroare la importarea cardurilor",
+    "fileReadError": "Eroare la citirea fișierului"
   },
   "guestPrompt": {
     "createDeck": {

--- a/src/api/decks.ts
+++ b/src/api/decks.ts
@@ -70,6 +70,7 @@ export async function exportDeck(
     fileName: string;
     content: string;
     mimeType: string;
+    cardsCount: number;
   }>(`/export/deck/${id}?format=${format}&includeProgress=${includeProgress}`);
 }
 

--- a/src/components/pages/DeckList/DeckList.tsx
+++ b/src/components/pages/DeckList/DeckList.tsx
@@ -1,29 +1,27 @@
-import React, { useState, useEffect, useMemo } from 'react';
+import React, { useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { Deck, DeckWithCards, Difficulty, Card } from '../../../types';
+import { Deck, DeckWithCards, Difficulty } from '../../../types';
 import {
   Plus,
   MoreVertical,
-  Upload,
   Sparkles,
-  Loader2,
   Trash2,
   Play,
   Edit,
   RotateCcw,
-  ArrowRight,
   List,
-  X,
-  Save,
   Star,
   Flag,
   ThumbsUp,
+  Download,
 } from 'lucide-react';
-import { generateDeckWithAI, getDeck } from '../../../api/decks';
-import { createCard, updateCard, deleteCard as deleteCardAPI } from '../../../api/cards';
+import { getDeck } from '../../../api/decks';
 import { useToast } from '../../ui/Toast';
 import { ReviewModal } from '../../reviews/ReviewModal';
 import { FlagModal } from '../../flags/FlagModal';
+import { GenerateCardsModal } from './GenerateCardsModal';
+import { EditCardsModal } from './EditCardsModal';
+import { ExportModal } from './ExportModal';
 
 interface DeckListProps {
   decks: Deck[];
@@ -46,68 +44,38 @@ export const DeckList: React.FC<DeckListProps> = ({
   isGuest = false,
   onLoginPrompt,
 }) => {
-  const { t, i18n } = useTranslation('decks');
+  const { t } = useTranslation('decks');
   const toast = useToast();
-  const [isModalOpen, setIsModalOpen] = useState(false);
-  const [isGenerating, setIsGenerating] = useState(false);
   const [activeMenuId, setActiveMenuId] = useState<string | null>(null);
 
-  // Form State
-  const [editingDeckId, setEditingDeckId] = useState<string | null>(null);
-  const [generatingForDeckId, setGeneratingForDeckId] = useState<string | null>(null);
-  const [title, setTitle] = useState('');
-  const [subject, setSubject] = useState('Limba Română');
-  const [difficulty, setDifficulty] = useState<Difficulty>('A2');
-  const [importMode, setImportMode] = useState<'manual' | 'ai' | 'file'>('ai');
-  const [numberOfCards, setNumberOfCards] = useState(10);
-  const [selectedCardTypes, setSelectedCardTypes] = useState<
-    Array<'standard' | 'quiz' | 'type-answer'>
-  >(['standard', 'quiz', 'type-answer']);
-  const [selectedLanguage, setSelectedLanguage] = useState('ro');
-  const [extraContext, setExtraContext] = useState('');
-
-  // Available languages with flags
-  const languages = useMemo(
-    () => [
-      { code: 'ro', name: 'Română', flag: '🇷🇴' },
-      { code: 'en', name: 'English', flag: '🇬🇧' },
-      { code: 'it', name: 'Italiano', flag: '🇮🇹' },
-    ],
-    []
+  // Generate/Create Modal State
+  const [isGenerateModalOpen, setIsGenerateModalOpen] = useState(false);
+  const [generateModalMode, setGenerateModalMode] = useState<'create' | 'edit' | 'generate'>(
+    'create'
   );
+  const [selectedDeckForGenerate, setSelectedDeckForGenerate] = useState<{
+    id: string;
+    title: string;
+    subject: string;
+    difficulty: Difficulty;
+  } | null>(null);
 
   // Edit Cards Modal State
   const [editCardsModalOpen, setEditCardsModalOpen] = useState(false);
   const [editCardsModalDeck, setEditCardsModalDeck] = useState<DeckWithCards | null>(null);
-  const [editingCardId, setEditingCardId] = useState<string | null>(null);
-  const [editCardFront, setEditCardFront] = useState('');
-  const [editCardBack, setEditCardBack] = useState('');
-  const [editCardContext, setEditCardContext] = useState('');
-  const [editCardType, setEditCardType] = useState<'standard' | 'type-answer' | 'quiz'>('standard');
-  const [editCardOptions, setEditCardOptions] = useState<string[]>(['', '', '', '']);
-  const [editCardCorrectIndex, setEditCardCorrectIndex] = useState(0);
-  const [isSavingCard, setIsSavingCard] = useState(false);
+
+  // Export Modal State
+  const [exportModalOpen, setExportModalOpen] = useState(false);
+  const [selectedDeckForExport, setSelectedDeckForExport] = useState<{
+    id: string;
+    title: string;
+  } | null>(null);
 
   // Review & Flag Modal State
   const [flagModalOpen, setFlagModalOpen] = useState(false);
   const [reviewModalOpen, setReviewModalOpen] = useState(false);
   const [selectedDeckForFlag, setSelectedDeckForFlag] = useState<Deck | null>(null);
   const [selectedDeckForReview, setSelectedDeckForReview] = useState<Deck | null>(null);
-
-  // Loading messages for "The Dealer's Table" loading state
-  const dealerMessages = t('loading.dealerMessages', { returnObjects: true }) as string[];
-  const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
-
-  // Rotate loading messages every 3 seconds
-  useEffect(() => {
-    if (!isGenerating) return;
-
-    const interval = setInterval(() => {
-      setCurrentMessageIndex(prev => (prev + 1) % dealerMessages.length);
-    }, 3000);
-
-    return () => clearInterval(interval);
-  }, [isGenerating, dealerMessages.length]);
 
   const openCreateModal = () => {
     // Guard: Visitors must register to create decks
@@ -116,28 +84,20 @@ export const DeckList: React.FC<DeckListProps> = ({
       return;
     }
 
-    setEditingDeckId(null);
-    setGeneratingForDeckId(null);
-    setTitle('');
-    setSubject('Limba Română');
-    setDifficulty('A2');
-    setImportMode('ai');
-    setNumberOfCards(10);
-    setSelectedCardTypes(['standard', 'quiz', 'type-answer']);
-    // Default to current app language
-    const currentLang = i18n.language?.split('-')[0] || 'ro';
-    setSelectedLanguage(['ro', 'en', 'it'].includes(currentLang) ? currentLang : 'ro');
-    setExtraContext('');
-    setIsModalOpen(true);
+    setGenerateModalMode('create');
+    setSelectedDeckForGenerate(null);
+    setIsGenerateModalOpen(true);
   };
 
   const openEditModal = (deck: Deck) => {
-    setEditingDeckId(deck.id);
-    setGeneratingForDeckId(null);
-    setTitle(deck.title);
-    setSubject(deck.subject);
-    setDifficulty(deck.difficulty);
-    setIsModalOpen(true);
+    setGenerateModalMode('edit');
+    setSelectedDeckForGenerate({
+      id: deck.id,
+      title: deck.title,
+      subject: deck.subject,
+      difficulty: deck.difficulty,
+    });
+    setIsGenerateModalOpen(true);
     setActiveMenuId(null);
   };
 
@@ -148,32 +108,15 @@ export const DeckList: React.FC<DeckListProps> = ({
       return;
     }
 
-    setEditingDeckId(null);
-    setGeneratingForDeckId(deck.id);
-    setTitle(deck.title || '');
-    setSubject(deck.subject);
-    setDifficulty(deck.difficulty);
-    setImportMode('ai');
-    setNumberOfCards(10);
-    setSelectedCardTypes(['standard', 'quiz', 'type-answer']);
-    // Default to current app language
-    const currentLang = i18n.language?.split('-')[0] || 'ro';
-    setSelectedLanguage(['ro', 'en', 'it'].includes(currentLang) ? currentLang : 'ro');
-    setExtraContext('');
-    setIsModalOpen(true);
-    setActiveMenuId(null);
-  };
-
-  const toggleCardType = (type: 'standard' | 'quiz' | 'type-answer') => {
-    setSelectedCardTypes(prev => {
-      if (prev.includes(type)) {
-        // Don't allow deselecting if it's the last selected type
-        if (prev.length === 1) return prev;
-        return prev.filter(t => t !== type);
-      } else {
-        return [...prev, type];
-      }
+    setGenerateModalMode('generate');
+    setSelectedDeckForGenerate({
+      id: deck.id,
+      title: deck.title || '',
+      subject: deck.subject,
+      difficulty: deck.difficulty,
     });
+    setIsGenerateModalOpen(true);
+    setActiveMenuId(null);
   };
 
   // Edit Cards Modal Functions
@@ -186,7 +129,7 @@ export const DeckList: React.FC<DeckListProps> = ({
         const deckWithCards: DeckWithCards = {
           ...response.data,
           subject: response.data.subjectName || response.data.subject,
-          masteredCards: deck.masteredCards || 0, // Preserve from original deck
+          masteredCards: deck.masteredCards || 0,
           cards: response.data.cards,
         };
         setEditCardsModalDeck(deckWithCards);
@@ -201,273 +144,13 @@ export const DeckList: React.FC<DeckListProps> = ({
     }
   };
 
-  const closeEditCardsModal = () => {
-    setEditCardsModalOpen(false);
-    setEditCardsModalDeck(null);
-    setEditingCardId(null);
-    setEditCardFront('');
-    setEditCardBack('');
-    setEditCardContext('');
-  };
-
-  const startEditCard = (card: Card) => {
-    setEditingCardId(card.id);
-    setEditCardFront(card.front);
-    setEditCardBack(card.back);
-    setEditCardContext(card.context || '');
-    setEditCardType(card.type);
-    if (card.type === 'quiz' && card.options && card.options.length > 0) {
-      setEditCardOptions([...card.options]);
-      setEditCardCorrectIndex(card.correctOptionIndex || 0);
-    } else {
-      setEditCardOptions(['', '', '', '']);
-      setEditCardCorrectIndex(0);
-    }
-  };
-
-  const cancelEditCard = () => {
-    setEditingCardId(null);
-    setEditCardFront('');
-    setEditCardBack('');
-    setEditCardContext('');
-  };
-
-  const saveEditCard = async () => {
-    if (!editCardsModalDeck || !editingCardId) return;
-
-    setIsSavingCard(true);
-    try {
-      const updateData: any = {
-        front: editCardFront,
-        back: editCardBack,
-        context: editCardContext || undefined,
-        type: editCardType,
-      };
-
-      // Add quiz-specific fields if needed
-      if (editCardType === 'quiz') {
-        updateData.options = editCardOptions.filter(opt => opt.trim() !== '');
-        updateData.correctOptionIndex = editCardCorrectIndex;
-      }
-
-      const response = await updateCard(editCardsModalDeck.id, editingCardId, updateData);
-
-      if (response.success) {
-        // Update local state with API response
-        const updatedCards = editCardsModalDeck.cards.map(card =>
-          card.id === editingCardId
-            ? {
-                ...card,
-                front: editCardFront,
-                back: editCardBack,
-                context: editCardContext,
-                type: editCardType,
-                options: editCardType === 'quiz' ? editCardOptions : undefined,
-                correctOptionIndex: editCardType === 'quiz' ? editCardCorrectIndex : undefined,
-              }
-            : card
-        );
-
-        const updatedDeck = { ...editCardsModalDeck, cards: updatedCards };
-        onEditDeck(updatedDeck);
-        setEditCardsModalDeck(updatedDeck);
-        cancelEditCard();
-        toast.success(t('toast.cardUpdated'));
-      } else {
-        toast.error(response.error?.message || t('toast.cardUpdateError'));
-      }
-    } catch (error) {
-      console.error('Error updating card:', error);
-      toast.error(t('toast.cardUpdateError'));
-    } finally {
-      setIsSavingCard(false);
-    }
-  };
-
-  const deleteCard = async (cardId: string) => {
-    if (!editCardsModalDeck) return;
-    if (!confirm(t('editCardsModal.deleteConfirm'))) return;
-
-    try {
-      const response = await deleteCardAPI(editCardsModalDeck.id, cardId);
-
-      if (response.success) {
-        const updatedCards = editCardsModalDeck.cards.filter(card => card.id !== cardId);
-        const updatedDeck = {
-          ...editCardsModalDeck,
-          cards: updatedCards,
-          totalCards: updatedCards.length,
-        };
-        onEditDeck(updatedDeck);
-        setEditCardsModalDeck(updatedDeck);
-        toast.success(t('toast.cardDeleted'));
-      } else {
-        toast.error(response.error?.message || t('toast.cardDeleteError'));
-      }
-    } catch (error) {
-      console.error('Error deleting card:', error);
-      toast.error(t('toast.cardDeleteError'));
-    }
-  };
-
-  const addNewCard = async () => {
-    if (!editCardsModalDeck) return;
-
-    try {
-      const response = await createCard({
-        deckId: editCardsModalDeck.id,
-        front: t('editCardsModal.newQuestion'),
-        back: t('editCardsModal.newAnswer'),
-        context: '',
-        type: 'standard',
-      });
-
-      if (response.success && response.data) {
-        const newCard: Card = response.data;
-
-        const updatedCards = [...editCardsModalDeck.cards, newCard];
-        const updatedDeck = {
-          ...editCardsModalDeck,
-          cards: updatedCards,
-          totalCards: updatedCards.length,
-        };
-        onEditDeck(updatedDeck);
-        setEditCardsModalDeck(updatedDeck);
-        startEditCard(newCard);
-        toast.success(t('toast.cardAdded'));
-      } else {
-        toast.error(response.error?.message || t('toast.cardAddError'));
-      }
-    } catch (error) {
-      console.error('Error creating card:', error);
-      toast.error(t('toast.cardAddError'));
-    }
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsGenerating(true);
-
-    if (editingDeckId) {
-      // EDIT MODE (metadata only - no cards)
-      const existingDeck = decks.find(d => d.id === editingDeckId);
-      if (existingDeck) {
-        const updatedDeck: DeckWithCards = {
-          ...existingDeck,
-          title,
-          subject,
-          difficulty,
-          cards: [], // Empty array - we're only updating metadata
-        };
-        onEditDeck(updatedDeck);
-      }
-    } else if (generatingForDeckId) {
-      // GENERATE CARDS FOR EXISTING EMPTY DECK
-      const newCards: Card[] = [];
-      if (importMode === 'ai') {
-        try {
-          const response = await generateDeckWithAI(
-            subject,
-            title,
-            difficulty,
-            numberOfCards,
-            selectedCardTypes,
-            selectedLanguage,
-            extraContext || undefined
-          );
-          if (response.success && response.data) {
-            newCards.push(
-              ...response.data.map((card, index) => ({
-                ...card,
-                id: `ai-${Date.now()}-${index}`,
-                deckId: generatingForDeckId || `d-${Date.now()}`,
-                position: index,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-              }))
-            );
-          } else {
-            alert(response.error?.message || t('toast.generationError'));
-            setIsGenerating(false);
-            return;
-          }
-        } catch (error) {
-          console.error('Error generating cards:', error);
-          alert(t('toast.generationError'));
-          setIsGenerating(false);
-          return;
-        }
-      }
-
-      const existingDeck = decks.find(d => d.id === generatingForDeckId);
-      if (existingDeck) {
-        const updatedDeck: DeckWithCards = {
-          ...existingDeck,
-          cards: newCards,
-          totalCards: newCards.length,
-          masteredCards: 0,
-        };
-        onEditDeck(updatedDeck);
-      }
-    } else {
-      // CREATE MODE
-      const newCards: Card[] = [];
-      if (importMode === 'ai') {
-        try {
-          const response = await generateDeckWithAI(
-            subject,
-            title,
-            difficulty,
-            numberOfCards,
-            selectedCardTypes,
-            selectedLanguage,
-            extraContext || undefined
-          );
-          if (response.success && response.data) {
-            newCards.push(
-              ...response.data.map((card, index) => ({
-                ...card,
-                id: `ai-${Date.now()}-${index}`,
-                deckId: generatingForDeckId || `d-${Date.now()}`,
-                position: index,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-              }))
-            );
-          } else {
-            alert(response.error?.message || t('toast.generationError'));
-            setIsGenerating(false);
-            return;
-          }
-        } catch (error) {
-          console.error('Error generating cards:', error);
-          alert(t('toast.generationError'));
-          setIsGenerating(false);
-          return;
-        }
-      }
-
-      const newDeck: DeckWithCards = {
-        id: `d-${Date.now()}`,
-        ownerId: '', // Will be set by backend
-        title,
-        subject,
-        topic: title, // Simplified
-        difficulty,
-        isPublic: false,
-        tags: [],
-        cards: newCards,
-        totalCards: newCards.length,
-        masteredCards: 0,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-      onAddDeck(newDeck);
-    }
-
-    setIsGenerating(false);
-    setIsModalOpen(false);
-    setTitle('');
+  const openExportModal = (deck: Deck) => {
+    setSelectedDeckForExport({
+      id: deck.id,
+      title: deck.title,
+    });
+    setExportModalOpen(true);
+    setActiveMenuId(null);
   };
 
   const toggleMenu = (e: React.MouseEvent, id: string) => {
@@ -584,6 +267,18 @@ export const DeckList: React.FC<DeckListProps> = ({
                           className="w-full text-left px-3 py-2 text-sm text-blue-600 hover:bg-blue-50 rounded-lg flex items-center gap-2 font-medium"
                         >
                           <List size={16} /> {t('menu.editCards')}
+                        </button>
+                      )}
+                      {/* Exportă carduri - Show if deck has at least 1 card */}
+                      {deck.totalCards > 0 && (
+                        <button
+                          onClick={e => {
+                            e.stopPropagation();
+                            openExportModal(deck);
+                          }}
+                          className="w-full text-left px-3 py-2 text-sm text-green-600 hover:bg-green-50 rounded-lg flex items-center gap-2 font-medium"
+                        >
+                          <Download size={16} /> {t('menu.exportDeck')}
                         </button>
                       )}
                       {/* Lasă o recenzie - Only for public decks, not owner */}
@@ -703,600 +398,42 @@ export const DeckList: React.FC<DeckListProps> = ({
         })}
       </div>
 
-      {/* Modal for New/Edit Deck (Code omitted for brevity as it's identical to previous, just wrapped in same component) */}
-      {isModalOpen && (
-        <div className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4 backdrop-blur-sm">
-          <div className="bg-white rounded-3xl w-full max-w-md max-h-[90vh] overflow-y-auto p-8 shadow-2xl animate-scale-up relative">
-            {/* "The Dealer's Table" Loading Overlay */}
-            {isGenerating && (
-              <div className="absolute inset-0 bg-gradient-to-br from-indigo-900/95 to-purple-900/95 rounded-3xl flex flex-col items-center justify-center z-50 backdrop-blur-sm">
-                {/* Juggling Cards Animation */}
-                <div className="relative w-32 h-32 mb-8">
-                  <div className="absolute inset-0 flex items-center justify-center">
-                    <div className="absolute animate-juggle-1">
-                      <div className="w-16 h-24 bg-gradient-to-br from-white to-gray-100 rounded-lg shadow-2xl border-2 border-gray-200 flex items-center justify-center text-3xl font-bold text-indigo-600">
-                        A
-                      </div>
-                    </div>
-                    <div className="absolute animate-juggle-2" style={{ animationDelay: '0.33s' }}>
-                      <div className="w-16 h-24 bg-gradient-to-br from-white to-gray-100 rounded-lg shadow-2xl border-2 border-gray-200 flex items-center justify-center text-3xl font-bold text-purple-600">
-                        K
-                      </div>
-                    </div>
-                    <div className="absolute animate-juggle-3" style={{ animationDelay: '0.66s' }}>
-                      <div className="w-16 h-24 bg-gradient-to-br from-white to-gray-100 rounded-lg shadow-2xl border-2 border-gray-200 flex items-center justify-center text-3xl font-bold text-pink-600">
-                        Q
-                      </div>
-                    </div>
-                  </div>
-                </div>
-
-                {/* Dynamic Rotating Messages */}
-                <p className="text-white text-center font-semibold text-base px-8 max-w-sm leading-relaxed animate-fade-in">
-                  {dealerMessages[currentMessageIndex]}
-                </p>
-
-                {/* Loading spinner */}
-                <Loader2 className="text-white animate-spin mt-6" size={24} />
-              </div>
-            )}
-
-            <h2 className="text-2xl font-bold mb-6 text-gray-900">
-              {editingDeckId
-                ? t('modal.editDeck')
-                : generatingForDeckId
-                  ? t('modal.generateCards')
-                  : t('modal.newDeck')}
-            </h2>
-            <form onSubmit={handleSubmit} className="space-y-6">
-              {/* Row 1: Subject (2/3) + Language (1/3) */}
-              <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-                <div className="sm:col-span-2">
-                  <label className="block text-sm font-bold text-gray-700 mb-2">
-                    {t('modal.subject')}
-                  </label>
-                  <select
-                    className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
-                    value={subject}
-                    onChange={e => setSubject(e.target.value)}
-                  >
-                    <option>Limba Română</option>
-                    <option>Matematică</option>
-                    <option>Istorie</option>
-                    <option>Geografie</option>
-                    <option>Engleză</option>
-                  </select>
-                </div>
-                <div>
-                  <label className="block text-sm font-bold text-gray-700 mb-2">
-                    {t('modal.language')}
-                  </label>
-                  <select
-                    className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
-                    value={selectedLanguage}
-                    onChange={e => setSelectedLanguage(e.target.value)}
-                  >
-                    {languages.map(lang => (
-                      <option key={lang.code} value={lang.code}>
-                        {lang.flag} {lang.name}
-                      </option>
-                    ))}
-                  </select>
-                </div>
-              </div>
-
-              {/* Row 2: Title/Topic (full width) */}
-              <div>
-                <label className="block text-sm font-bold text-gray-700 mb-2">
-                  {t('modal.titleLabel')}
-                </label>
-                <input
-                  type="text"
-                  className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
-                  placeholder={t('modal.titlePlaceholder')}
-                  value={title}
-                  onChange={e => setTitle(e.target.value)}
-                  required
-                />
-              </div>
-
-              {!editingDeckId && !generatingForDeckId && (
-                <>
-                  {/* Row 3: Number of Cards (50%) + Difficulty (50%) */}
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-sm font-bold text-gray-700 mb-2">
-                        {importMode === 'ai'
-                          ? t('modal.numberOfCardsAI')
-                          : t('modal.numberOfCards')}
-                      </label>
-                      <input
-                        type="number"
-                        min="5"
-                        max="50"
-                        value={numberOfCards}
-                        onChange={e => setNumberOfCards(parseInt(e.target.value) || 10)}
-                        className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors disabled:opacity-50"
-                        disabled={importMode !== 'ai'}
-                      />
-                      <p className="text-xs text-gray-500 mt-1">
-                        {importMode === 'ai'
-                          ? t('modal.cardsRecommendation')
-                          : t('modal.cardsFromFile')}
-                      </p>
-                    </div>
-                    <div>
-                      <label className="block text-sm font-bold text-gray-700 mb-2">
-                        {t('modal.difficultyLabel')}
-                      </label>
-                      <select
-                        className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
-                        value={difficulty}
-                        onChange={e => setDifficulty(e.target.value as Difficulty)}
-                      >
-                        <option value="A1">A1 - {t('difficulty.A1')}</option>
-                        <option value="A2">A2 - {t('difficulty.A2')}</option>
-                        <option value="B1">B1 - {t('difficulty.B1')}</option>
-                        <option value="B2">B2 - {t('difficulty.B2')}</option>
-                        <option value="C1">C1 - {t('difficulty.C1')}</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <div className="pt-2">
-                    <label className="block text-sm font-bold text-gray-700 mb-2">
-                      {t('modal.creationMethod')}
-                    </label>
-                    <div className="grid grid-cols-3 gap-3">
-                      <button
-                        type="button"
-                        onClick={() => setImportMode('ai')}
-                        className={`p-3 rounded-xl border-2 text-sm flex flex-col items-center gap-1 font-bold transition-all ${importMode === 'ai' ? 'bg-indigo-50 border-indigo-500 text-indigo-700' : 'border-gray-100 text-gray-500 hover:bg-gray-50'}`}
-                      >
-                        <Sparkles size={20} /> {t('modal.aiAuto')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setImportMode('file')}
-                        className={`p-3 rounded-xl border-2 text-sm flex flex-col items-center gap-1 font-bold transition-all ${importMode === 'file' ? 'bg-indigo-50 border-indigo-500 text-indigo-700' : 'border-gray-100 text-gray-500 hover:bg-gray-50'}`}
-                      >
-                        <Upload size={20} /> {t('modal.import')}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setImportMode('manual')}
-                        className={`p-3 rounded-xl border-2 text-sm flex flex-col items-center gap-1 font-bold transition-all ${importMode === 'manual' ? 'bg-indigo-50 border-indigo-500 text-indigo-700' : 'border-gray-100 text-gray-500 hover:bg-gray-50'}`}
-                      >
-                        <Plus size={20} /> {t('modal.manual')}
-                      </button>
-                    </div>
-                  </div>
-
-                  {importMode === 'ai' && (
-                    <>
-                      <div>
-                        <label className="block text-sm font-bold text-gray-700 mb-3">
-                          {t('modal.cardTypes')}
-                        </label>
-                        <div className="space-y-2">
-                          <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
-                            <input
-                              type="checkbox"
-                              checked={selectedCardTypes.includes('standard')}
-                              onChange={() => toggleCardType('standard')}
-                              className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                            />
-                            <div className="flex-1">
-                              <span className="font-semibold text-gray-900">
-                                {t('modal.standard')}
-                              </span>
-                              <p className="text-xs text-gray-600">{t('modal.standardDesc')}</p>
-                            </div>
-                          </label>
-
-                          <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
-                            <input
-                              type="checkbox"
-                              checked={selectedCardTypes.includes('quiz')}
-                              onChange={() => toggleCardType('quiz')}
-                              className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                            />
-                            <div className="flex-1">
-                              <span className="font-semibold text-gray-900">{t('modal.quiz')}</span>
-                              <p className="text-xs text-gray-600">{t('modal.quizDesc')}</p>
-                            </div>
-                          </label>
-
-                          <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
-                            <input
-                              type="checkbox"
-                              checked={selectedCardTypes.includes('type-answer')}
-                              onChange={() => toggleCardType('type-answer')}
-                              className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                            />
-                            <div className="flex-1">
-                              <span className="font-semibold text-gray-900">
-                                {t('modal.typeAnswer')}
-                              </span>
-                              <p className="text-xs text-gray-600">{t('modal.typeAnswerDesc')}</p>
-                            </div>
-                          </label>
-                        </div>
-                        <p className="text-xs text-gray-500 mt-2">{t('modal.deselectCardType')}</p>
-                      </div>
-
-                      {/* Extra Context textarea */}
-                      <div>
-                        <label className="block text-sm font-bold text-gray-700 mb-2">
-                          {t('modal.extraContext')}
-                        </label>
-                        <textarea
-                          className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors min-h-[120px] resize-y"
-                          placeholder={t('modal.extraContextPlaceholder')}
-                          value={extraContext}
-                          onChange={e => setExtraContext(e.target.value)}
-                          maxLength={2000}
-                        />
-                        <p className="text-xs text-gray-500 mt-1">
-                          {t('modal.extraContextHelper')}
-                        </p>
-                      </div>
-                    </>
-                  )}
-                </>
-              )}
-
-              {generatingForDeckId && (
-                <>
-                  {/* Row 3: Number of Cards (50%) + Difficulty (50%) */}
-                  <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-                    <div>
-                      <label className="block text-sm font-bold text-gray-700 mb-2">
-                        {t('modal.numberOfCardsAI')}
-                      </label>
-                      <input
-                        type="number"
-                        min="5"
-                        max="50"
-                        value={numberOfCards}
-                        onChange={e => setNumberOfCards(parseInt(e.target.value) || 10)}
-                        className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
-                      />
-                      <p className="text-xs text-gray-500 mt-1">{t('modal.cardsRecommendation')}</p>
-                    </div>
-                    <div>
-                      <label className="block text-sm font-bold text-gray-700 mb-2">
-                        {t('modal.difficultyLabel')}
-                      </label>
-                      <select
-                        className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
-                        value={difficulty}
-                        onChange={e => setDifficulty(e.target.value as Difficulty)}
-                      >
-                        <option value="A1">A1 - {t('difficulty.A1')}</option>
-                        <option value="A2">A2 - {t('difficulty.A2')}</option>
-                        <option value="B1">B1 - {t('difficulty.B1')}</option>
-                        <option value="B2">B2 - {t('difficulty.B2')}</option>
-                        <option value="C1">C1 - {t('difficulty.C1')}</option>
-                      </select>
-                    </div>
-                  </div>
-
-                  <div>
-                    <label className="block text-sm font-bold text-gray-700 mb-3">
-                      {t('modal.cardTypes')}
-                    </label>
-                    <div className="space-y-2">
-                      <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={selectedCardTypes.includes('standard')}
-                          onChange={() => toggleCardType('standard')}
-                          className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                        />
-                        <div className="flex-1">
-                          <span className="font-semibold text-gray-900">{t('modal.standard')}</span>
-                          <p className="text-xs text-gray-600">{t('modal.standardDesc')}</p>
-                        </div>
-                      </label>
-
-                      <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={selectedCardTypes.includes('quiz')}
-                          onChange={() => toggleCardType('quiz')}
-                          className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                        />
-                        <div className="flex-1">
-                          <span className="font-semibold text-gray-900">{t('modal.quiz')}</span>
-                          <p className="text-xs text-gray-600">{t('modal.quizDesc')}</p>
-                        </div>
-                      </label>
-
-                      <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
-                        <input
-                          type="checkbox"
-                          checked={selectedCardTypes.includes('type-answer')}
-                          onChange={() => toggleCardType('type-answer')}
-                          className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
-                        />
-                        <div className="flex-1">
-                          <span className="font-semibold text-gray-900">
-                            {t('modal.typeAnswer')}
-                          </span>
-                          <p className="text-xs text-gray-600">{t('modal.typeAnswerDesc')}</p>
-                        </div>
-                      </label>
-                    </div>
-                    <p className="text-xs text-gray-500 mt-2">{t('modal.deselectCardType')}</p>
-                  </div>
-
-                  {/* Extra Context textarea */}
-                  <div>
-                    <label className="block text-sm font-bold text-gray-700 mb-2">
-                      {t('modal.extraContext')}
-                    </label>
-                    <textarea
-                      className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors min-h-[120px] resize-y"
-                      placeholder={t('modal.extraContextPlaceholder')}
-                      value={extraContext}
-                      onChange={e => setExtraContext(e.target.value)}
-                      maxLength={2000}
-                    />
-                    <p className="text-xs text-gray-500 mt-1">{t('modal.extraContextHelper')}</p>
-                  </div>
-                </>
-              )}
-
-              {importMode === 'file' && !editingDeckId && !generatingForDeckId && (
-                <div className="border-2 border-dashed border-gray-300 rounded-xl p-6 text-center bg-gray-50">
-                  <input type="file" accept=".txt,.csv" className="w-full text-sm text-gray-500" />
-                  <p className="text-xs text-gray-400 mt-2 font-medium">{t('modal.fileImport')}</p>
-                </div>
-              )}
-
-              <div className="flex gap-4 pt-4">
-                <button
-                  type="button"
-                  onClick={() => setIsModalOpen(false)}
-                  className="flex-1 bg-white border-2 border-gray-200 text-gray-700 font-bold py-3 rounded-xl hover:bg-gray-50 transition-colors"
-                >
-                  {t('modal.cancel')}
-                </button>
-                <button
-                  type="submit"
-                  disabled={isGenerating}
-                  className="flex-1 bg-gray-900 text-white font-bold py-3 rounded-xl hover:bg-gray-800 transition-colors flex justify-center items-center gap-2 shadow-lg hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {isGenerating ? (
-                    <Loader2 className="animate-spin" />
-                  ) : editingDeckId ? (
-                    t('modal.save')
-                  ) : generatingForDeckId ? (
-                    t('modal.generateCardsBtn')
-                  ) : (
-                    t('modal.createDeck')
-                  )}
-                </button>
-              </div>
-            </form>
-          </div>
-        </div>
-      )}
+      {/* Generate/Create/Edit Modal */}
+      <GenerateCardsModal
+        isOpen={isGenerateModalOpen}
+        onClose={() => setIsGenerateModalOpen(false)}
+        mode={generateModalMode}
+        existingDeck={selectedDeckForGenerate}
+        onAddDeck={onAddDeck}
+        onEditDeck={onEditDeck}
+        decks={decks}
+      />
 
       {/* Edit Cards Modal */}
-      {editCardsModalOpen && editCardsModalDeck && (
-        <div
-          className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4 backdrop-blur-sm"
-          onClick={closeEditCardsModal}
-        >
-          <div
-            className="bg-white rounded-3xl w-full max-w-3xl max-h-[90vh] overflow-hidden shadow-2xl animate-scale-up flex flex-col"
-            onClick={e => e.stopPropagation()}
-          >
-            {/* Header */}
-            <div className="p-6 border-b border-gray-100 flex justify-between items-center">
-              <div>
-                <h2 className="text-2xl font-bold text-gray-900">{t('editCardsModal.title')}</h2>
-                <p className="text-sm text-gray-500 mt-1">
-                  {t('editCardsModal.subtitle', {
-                    title: editCardsModalDeck.title,
-                    count: editCardsModalDeck.cards.length,
-                  })}
-                </p>
-              </div>
-              <button
-                onClick={closeEditCardsModal}
-                className="text-gray-400 hover:text-gray-900 p-2 hover:bg-gray-100 rounded-full transition-colors"
-              >
-                <X size={24} />
-              </button>
-            </div>
+      <EditCardsModal
+        isOpen={editCardsModalOpen}
+        deck={editCardsModalDeck}
+        onClose={() => {
+          setEditCardsModalOpen(false);
+          setEditCardsModalDeck(null);
+        }}
+        onDeckUpdate={updatedDeck => {
+          onEditDeck(updatedDeck);
+          setEditCardsModalDeck(updatedDeck);
+        }}
+      />
 
-            {/* Cards List */}
-            <div className="flex-1 overflow-y-auto p-6 space-y-4">
-              {editCardsModalDeck.cards.length === 0 ? (
-                <div className="text-center py-12 text-gray-400">
-                  <p className="font-medium">{t('editCardsModal.noCards')}</p>
-                  <p className="text-sm mt-1">{t('editCardsModal.addFirstCard')}</p>
-                </div>
-              ) : (
-                editCardsModalDeck.cards.map((card, index) => (
-                  <div
-                    key={card.id}
-                    className="bg-gray-50 rounded-xl p-4 border border-gray-200 hover:border-indigo-300 transition-colors"
-                  >
-                    {editingCardId === card.id ? (
-                      // Edit Mode
-                      <div className="space-y-3">
-                        <div>
-                          <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
-                            {t('editCardsModal.front')}
-                          </label>
-                          <input
-                            type="text"
-                            className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
-                            value={editCardFront}
-                            onChange={e => setEditCardFront(e.target.value)}
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
-                            {t('editCardsModal.back')}
-                          </label>
-                          <input
-                            type="text"
-                            className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
-                            value={editCardBack}
-                            onChange={e => setEditCardBack(e.target.value)}
-                          />
-                        </div>
-                        <div>
-                          <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
-                            {t('editCardsModal.context')}
-                          </label>
-                          <input
-                            type="text"
-                            className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
-                            value={editCardContext}
-                            onChange={e => setEditCardContext(e.target.value)}
-                            placeholder={t('editCardsModal.contextPlaceholder')}
-                          />
-                        </div>
-
-                        {/* Card Type Selection */}
-                        <div>
-                          <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
-                            {t('editCardsModal.cardType')}
-                          </label>
-                          <select
-                            className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
-                            value={editCardType}
-                            onChange={e =>
-                              setEditCardType(e.target.value as 'standard' | 'type-answer' | 'quiz')
-                            }
-                          >
-                            <option value="standard">{t('modal.standard')}</option>
-                            <option value="type-answer">{t('modal.typeAnswer')}</option>
-                            <option value="quiz">{t('modal.quiz')}</option>
-                          </select>
-                        </div>
-
-                        {/* Quiz Options (only for quiz type) */}
-                        {editCardType === 'quiz' && (
-                          <div className="space-y-2">
-                            <label className="block text-xs font-bold text-gray-500 uppercase">
-                              {t('editCardsModal.quizOptions')}
-                            </label>
-                            {editCardOptions.map((option, idx) => (
-                              <div key={idx} className="flex items-center gap-2">
-                                <input
-                                  type="radio"
-                                  name="correctOption"
-                                  checked={editCardCorrectIndex === idx}
-                                  onChange={() => setEditCardCorrectIndex(idx)}
-                                  className="w-4 h-4 text-indigo-600"
-                                />
-                                <input
-                                  type="text"
-                                  className="flex-1 border-2 border-gray-200 bg-white rounded-lg p-2 text-sm font-medium focus:border-indigo-500 outline-none"
-                                  value={option}
-                                  onChange={e => {
-                                    const newOptions = [...editCardOptions];
-                                    newOptions[idx] = e.target.value;
-                                    setEditCardOptions(newOptions);
-                                  }}
-                                  placeholder={t('editCardsModal.option', { number: idx + 1 })}
-                                />
-                              </div>
-                            ))}
-                            <p className="text-xs text-gray-500">
-                              {t('editCardsModal.selectCorrect')}
-                            </p>
-                          </div>
-                        )}
-
-                        <div className="flex gap-2">
-                          <button
-                            onClick={saveEditCard}
-                            disabled={isSavingCard}
-                            className="flex-1 bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
-                          >
-                            <Save size={16} />{' '}
-                            {isSavingCard ? t('editCardsModal.saving') : t('editCardsModal.save')}
-                          </button>
-                          <button
-                            onClick={cancelEditCard}
-                            className="flex-1 bg-white border-2 border-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors"
-                          >
-                            {t('editCardsModal.cancel')}
-                          </button>
-                        </div>
-                      </div>
-                    ) : (
-                      // View Mode
-                      <div>
-                        <div className="flex justify-between items-start mb-2">
-                          <span className="text-xs font-bold text-gray-400 uppercase">
-                            {t('editCardsModal.cardNumber', { number: index + 1 })}
-                          </span>
-                          <div className="flex gap-2">
-                            <button
-                              onClick={() => startEditCard(card)}
-                              className="p-1.5 text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
-                              title={t('editCardsModal.edit')}
-                            >
-                              <Edit size={16} />
-                            </button>
-                            <button
-                              onClick={() => deleteCard(card.id)}
-                              className="p-1.5 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                              title={t('editCardsModal.delete')}
-                            >
-                              <Trash2 size={16} />
-                            </button>
-                          </div>
-                        </div>
-                        <div className="space-y-2">
-                          <div>
-                            <p className="text-xs font-bold text-gray-500">
-                              {t('editCardsModal.question')}
-                            </p>
-                            <p className="text-sm font-medium text-gray-900">{card.front}</p>
-                          </div>
-                          <div>
-                            <p className="text-xs font-bold text-gray-500">
-                              {t('editCardsModal.answer')}
-                            </p>
-                            <p className="text-sm font-medium text-gray-900">{card.back}</p>
-                          </div>
-                          {card.context && (
-                            <div>
-                              <p className="text-xs font-bold text-gray-500">
-                                {t('editCardsModal.contextLabel')}
-                              </p>
-                              <p className="text-sm text-gray-600 italic">{card.context}</p>
-                            </div>
-                          )}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                ))
-              )}
-            </div>
-
-            {/* Footer */}
-            <div className="p-6 border-t border-gray-100">
-              <button
-                onClick={addNewCard}
-                className="w-full bg-gray-900 text-white font-bold py-3 rounded-xl hover:bg-gray-800 transition-colors flex items-center justify-center gap-2"
-              >
-                <Plus size={20} /> {t('editCardsModal.addNewCard')}
-              </button>
-            </div>
-          </div>
-        </div>
+      {/* Export Modal */}
+      {selectedDeckForExport && (
+        <ExportModal
+          isOpen={exportModalOpen}
+          deckId={selectedDeckForExport.id}
+          deckTitle={selectedDeckForExport.title}
+          onClose={() => {
+            setExportModalOpen(false);
+            setSelectedDeckForExport(null);
+          }}
+        />
       )}
 
       {/* Review Modal */}

--- a/src/components/pages/DeckList/EditCardsModal.tsx
+++ b/src/components/pages/DeckList/EditCardsModal.tsx
@@ -1,0 +1,383 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Card, DeckWithCards } from '../../../types';
+import { Plus, X, Edit, Trash2, Save } from 'lucide-react';
+import { createCard, updateCard, deleteCard as deleteCardAPI } from '../../../api/cards';
+import { useToast } from '../../ui/Toast';
+
+interface EditCardsModalProps {
+  isOpen: boolean;
+  deck: DeckWithCards | null;
+  onClose: () => void;
+  onDeckUpdate: (deck: DeckWithCards) => void;
+}
+
+export const EditCardsModal: React.FC<EditCardsModalProps> = ({
+  isOpen,
+  deck,
+  onClose,
+  onDeckUpdate,
+}) => {
+  const { t } = useTranslation('decks');
+  const toast = useToast();
+
+  // Edit card state
+  const [editingCardId, setEditingCardId] = useState<string | null>(null);
+  const [editCardFront, setEditCardFront] = useState('');
+  const [editCardBack, setEditCardBack] = useState('');
+  const [editCardContext, setEditCardContext] = useState('');
+  const [editCardType, setEditCardType] = useState<'standard' | 'type-answer' | 'quiz'>('standard');
+  const [editCardOptions, setEditCardOptions] = useState<string[]>(['', '', '', '']);
+  const [editCardCorrectIndex, setEditCardCorrectIndex] = useState(0);
+  const [isSavingCard, setIsSavingCard] = useState(false);
+
+  const startEditCard = (card: Card) => {
+    setEditingCardId(card.id);
+    setEditCardFront(card.front);
+    setEditCardBack(card.back);
+    setEditCardContext(card.context || '');
+    setEditCardType(card.type);
+    if (card.type === 'quiz' && card.options && card.options.length > 0) {
+      setEditCardOptions([...card.options]);
+      setEditCardCorrectIndex(card.correctOptionIndex || 0);
+    } else {
+      setEditCardOptions(['', '', '', '']);
+      setEditCardCorrectIndex(0);
+    }
+  };
+
+  const cancelEditCard = () => {
+    setEditingCardId(null);
+    setEditCardFront('');
+    setEditCardBack('');
+    setEditCardContext('');
+  };
+
+  const saveEditCard = async () => {
+    if (!deck || !editingCardId) return;
+
+    setIsSavingCard(true);
+    try {
+      const updateData: Record<string, unknown> = {
+        front: editCardFront,
+        back: editCardBack,
+        context: editCardContext || undefined,
+        type: editCardType,
+      };
+
+      // Add quiz-specific fields if needed
+      if (editCardType === 'quiz') {
+        updateData.options = editCardOptions.filter(opt => opt.trim() !== '');
+        updateData.correctOptionIndex = editCardCorrectIndex;
+      }
+
+      const response = await updateCard(deck.id, editingCardId, updateData);
+
+      if (response.success) {
+        // Update local state with API response
+        const updatedCards = deck.cards.map(card =>
+          card.id === editingCardId
+            ? {
+                ...card,
+                front: editCardFront,
+                back: editCardBack,
+                context: editCardContext,
+                type: editCardType,
+                options: editCardType === 'quiz' ? editCardOptions : undefined,
+                correctOptionIndex: editCardType === 'quiz' ? editCardCorrectIndex : undefined,
+              }
+            : card
+        );
+
+        const updatedDeck = { ...deck, cards: updatedCards };
+        onDeckUpdate(updatedDeck);
+        cancelEditCard();
+        toast.success(t('toast.cardUpdated'));
+      } else {
+        toast.error(response.error?.message || t('toast.cardUpdateError'));
+      }
+    } catch (error) {
+      console.error('Error updating card:', error);
+      toast.error(t('toast.cardUpdateError'));
+    } finally {
+      setIsSavingCard(false);
+    }
+  };
+
+  const handleDeleteCard = async (cardId: string) => {
+    if (!deck) return;
+    if (!confirm(t('editCardsModal.deleteConfirm'))) return;
+
+    try {
+      const response = await deleteCardAPI(deck.id, cardId);
+
+      if (response.success) {
+        const updatedCards = deck.cards.filter(card => card.id !== cardId);
+        const updatedDeck = {
+          ...deck,
+          cards: updatedCards,
+          totalCards: updatedCards.length,
+        };
+        onDeckUpdate(updatedDeck);
+        toast.success(t('toast.cardDeleted'));
+      } else {
+        toast.error(response.error?.message || t('toast.cardDeleteError'));
+      }
+    } catch (error) {
+      console.error('Error deleting card:', error);
+      toast.error(t('toast.cardDeleteError'));
+    }
+  };
+
+  const addNewCard = async () => {
+    if (!deck) return;
+
+    try {
+      const response = await createCard({
+        deckId: deck.id,
+        front: t('editCardsModal.newQuestion'),
+        back: t('editCardsModal.newAnswer'),
+        context: '',
+        type: 'standard',
+      });
+
+      if (response.success && response.data) {
+        const newCard: Card = response.data;
+
+        const updatedCards = [...deck.cards, newCard];
+        const updatedDeck = {
+          ...deck,
+          cards: updatedCards,
+          totalCards: updatedCards.length,
+        };
+        onDeckUpdate(updatedDeck);
+        startEditCard(newCard);
+        toast.success(t('toast.cardAdded'));
+      } else {
+        toast.error(response.error?.message || t('toast.cardAddError'));
+      }
+    } catch (error) {
+      console.error('Error creating card:', error);
+      toast.error(t('toast.cardAddError'));
+    }
+  };
+
+  const handleClose = () => {
+    cancelEditCard();
+    onClose();
+  };
+
+  if (!isOpen || !deck) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4 backdrop-blur-sm"
+      onClick={handleClose}
+    >
+      <div
+        className="bg-white rounded-3xl w-full max-w-3xl max-h-[90vh] overflow-hidden shadow-2xl animate-scale-up flex flex-col"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-6 border-b border-gray-100 flex justify-between items-center">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900">{t('editCardsModal.title')}</h2>
+            <p className="text-sm text-gray-500 mt-1">
+              {t('editCardsModal.subtitle', {
+                title: deck.title,
+                count: deck.cards.length,
+              })}
+            </p>
+          </div>
+          <button
+            onClick={handleClose}
+            className="text-gray-400 hover:text-gray-900 p-2 hover:bg-gray-100 rounded-full transition-colors"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        {/* Cards List */}
+        <div className="flex-1 overflow-y-auto p-6 space-y-4">
+          {deck.cards.length === 0 ? (
+            <div className="text-center py-12 text-gray-400">
+              <p className="font-medium">{t('editCardsModal.noCards')}</p>
+              <p className="text-sm mt-1">{t('editCardsModal.addFirstCard')}</p>
+            </div>
+          ) : (
+            deck.cards.map((card, index) => (
+              <div
+                key={card.id}
+                className="bg-gray-50 rounded-xl p-4 border border-gray-200 hover:border-indigo-300 transition-colors"
+              >
+                {editingCardId === card.id ? (
+                  // Edit Mode
+                  <div className="space-y-3">
+                    <div>
+                      <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
+                        {t('editCardsModal.front')}
+                      </label>
+                      <input
+                        type="text"
+                        className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
+                        value={editCardFront}
+                        onChange={e => setEditCardFront(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
+                        {t('editCardsModal.back')}
+                      </label>
+                      <input
+                        type="text"
+                        className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
+                        value={editCardBack}
+                        onChange={e => setEditCardBack(e.target.value)}
+                      />
+                    </div>
+                    <div>
+                      <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
+                        {t('editCardsModal.context')}
+                      </label>
+                      <input
+                        type="text"
+                        className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
+                        value={editCardContext}
+                        onChange={e => setEditCardContext(e.target.value)}
+                        placeholder={t('editCardsModal.contextPlaceholder')}
+                      />
+                    </div>
+
+                    {/* Card Type Selection */}
+                    <div>
+                      <label className="block text-xs font-bold text-gray-500 uppercase mb-1">
+                        {t('editCardsModal.cardType')}
+                      </label>
+                      <select
+                        className="w-full border-2 border-gray-200 bg-white rounded-lg p-2 font-medium focus:border-indigo-500 outline-none"
+                        value={editCardType}
+                        onChange={e =>
+                          setEditCardType(e.target.value as 'standard' | 'type-answer' | 'quiz')
+                        }
+                      >
+                        <option value="standard">{t('modal.standard')}</option>
+                        <option value="type-answer">{t('modal.typeAnswer')}</option>
+                        <option value="quiz">{t('modal.quiz')}</option>
+                      </select>
+                    </div>
+
+                    {/* Quiz Options (only for quiz type) */}
+                    {editCardType === 'quiz' && (
+                      <div className="space-y-2">
+                        <label className="block text-xs font-bold text-gray-500 uppercase">
+                          {t('editCardsModal.quizOptions')}
+                        </label>
+                        {editCardOptions.map((option, idx) => (
+                          <div key={idx} className="flex items-center gap-2">
+                            <input
+                              type="radio"
+                              name="correctOption"
+                              checked={editCardCorrectIndex === idx}
+                              onChange={() => setEditCardCorrectIndex(idx)}
+                              className="w-4 h-4 text-indigo-600"
+                            />
+                            <input
+                              type="text"
+                              className="flex-1 border-2 border-gray-200 bg-white rounded-lg p-2 text-sm font-medium focus:border-indigo-500 outline-none"
+                              value={option}
+                              onChange={e => {
+                                const newOptions = [...editCardOptions];
+                                newOptions[idx] = e.target.value;
+                                setEditCardOptions(newOptions);
+                              }}
+                              placeholder={t('editCardsModal.option', { number: idx + 1 })}
+                            />
+                          </div>
+                        ))}
+                        <p className="text-xs text-gray-500">{t('editCardsModal.selectCorrect')}</p>
+                      </div>
+                    )}
+
+                    <div className="flex gap-2">
+                      <button
+                        onClick={saveEditCard}
+                        disabled={isSavingCard}
+                        className="flex-1 bg-indigo-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+                      >
+                        <Save size={16} />{' '}
+                        {isSavingCard ? t('editCardsModal.saving') : t('editCardsModal.save')}
+                      </button>
+                      <button
+                        onClick={cancelEditCard}
+                        className="flex-1 bg-white border-2 border-gray-200 text-gray-700 font-bold py-2 px-4 rounded-lg hover:bg-gray-50 transition-colors"
+                      >
+                        {t('editCardsModal.cancel')}
+                      </button>
+                    </div>
+                  </div>
+                ) : (
+                  // View Mode
+                  <div>
+                    <div className="flex justify-between items-start mb-2">
+                      <span className="text-xs font-bold text-gray-400 uppercase">
+                        {t('editCardsModal.cardNumber', { number: index + 1 })}
+                      </span>
+                      <div className="flex gap-2">
+                        <button
+                          onClick={() => startEditCard(card)}
+                          className="p-1.5 text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors"
+                          title={t('editCardsModal.edit')}
+                        >
+                          <Edit size={16} />
+                        </button>
+                        <button
+                          onClick={() => handleDeleteCard(card.id)}
+                          className="p-1.5 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                          title={t('editCardsModal.delete')}
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </div>
+                    </div>
+                    <div className="space-y-2">
+                      <div>
+                        <p className="text-xs font-bold text-gray-500">
+                          {t('editCardsModal.question')}
+                        </p>
+                        <p className="text-sm font-medium text-gray-900">{card.front}</p>
+                      </div>
+                      <div>
+                        <p className="text-xs font-bold text-gray-500">
+                          {t('editCardsModal.answer')}
+                        </p>
+                        <p className="text-sm font-medium text-gray-900">{card.back}</p>
+                      </div>
+                      {card.context && (
+                        <div>
+                          <p className="text-xs font-bold text-gray-500">
+                            {t('editCardsModal.contextLabel')}
+                          </p>
+                          <p className="text-sm text-gray-600 italic">{card.context}</p>
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))
+          )}
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-100">
+          <button
+            onClick={addNewCard}
+            className="w-full bg-gray-900 text-white font-bold py-3 rounded-xl hover:bg-gray-800 transition-colors flex items-center justify-center gap-2"
+          >
+            <Plus size={20} /> {t('editCardsModal.addNewCard')}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/pages/DeckList/ExportModal.tsx
+++ b/src/components/pages/DeckList/ExportModal.tsx
@@ -1,0 +1,189 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { X, Download, FileText, FileSpreadsheet, Loader2 } from 'lucide-react';
+import { exportDeck, downloadExportedDeck } from '../../../api/decks';
+import { useToast } from '../../ui/Toast';
+
+interface ExportModalProps {
+  isOpen: boolean;
+  deckId: string;
+  deckTitle: string;
+  onClose: () => void;
+}
+
+export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, deckId, deckTitle, onClose }) => {
+  const { t } = useTranslation('decks');
+  const toast = useToast();
+  const [selectedFormat, setSelectedFormat] = useState<'csv' | 'txt'>('csv');
+  const [includeProgress, setIncludeProgress] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const handleExport = async () => {
+    setIsExporting(true);
+    try {
+      const response = await exportDeck(deckId, selectedFormat, includeProgress);
+
+      if (response.success && response.data) {
+        downloadExportedDeck(response.data.fileName, response.data.content, response.data.mimeType);
+        toast.success(t('toast.exportSuccess', { count: response.data.cardsCount }));
+        onClose();
+      } else {
+        toast.error(response.error?.message || t('toast.exportError'));
+      }
+    } catch (error) {
+      console.error('Export error:', error);
+      toast.error(t('toast.exportError'));
+    } finally {
+      setIsExporting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 z-[70] flex items-center justify-center p-4 backdrop-blur-sm"
+      onClick={onClose}
+    >
+      <div
+        className="bg-white rounded-3xl w-full max-w-md overflow-hidden shadow-2xl animate-scale-up"
+        onClick={e => e.stopPropagation()}
+      >
+        {/* Header */}
+        <div className="p-6 border-b border-gray-100 flex justify-between items-center">
+          <div>
+            <h2 className="text-2xl font-bold text-gray-900">{t('exportModal.title')}</h2>
+            <p className="text-sm text-gray-500 mt-1">
+              {t('exportModal.subtitle', { title: deckTitle })}
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-gray-900 p-2 hover:bg-gray-100 rounded-full transition-colors"
+          >
+            <X size={24} />
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="p-6 space-y-6">
+          {/* Format Selection */}
+          <div>
+            <label className="block text-sm font-bold text-gray-700 mb-3">
+              {t('exportModal.selectFormat')}
+            </label>
+            <div className="grid grid-cols-2 gap-3">
+              <button
+                type="button"
+                onClick={() => setSelectedFormat('csv')}
+                className={`p-4 rounded-xl border-2 flex flex-col items-center gap-2 font-bold transition-all ${
+                  selectedFormat === 'csv'
+                    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                    : 'border-gray-200 text-gray-500 hover:bg-gray-50'
+                }`}
+              >
+                <FileSpreadsheet size={24} />
+                <span>CSV</span>
+                <span className="text-xs font-normal text-gray-500">
+                  {t('exportModal.csvDesc')}
+                </span>
+              </button>
+              <button
+                type="button"
+                onClick={() => setSelectedFormat('txt')}
+                className={`p-4 rounded-xl border-2 flex flex-col items-center gap-2 font-bold transition-all ${
+                  selectedFormat === 'txt'
+                    ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                    : 'border-gray-200 text-gray-500 hover:bg-gray-50'
+                }`}
+              >
+                <FileText size={24} />
+                <span>TXT</span>
+                <span className="text-xs font-normal text-gray-500">
+                  {t('exportModal.txtDesc')}
+                </span>
+              </button>
+            </div>
+          </div>
+
+          {/* Include Progress Option */}
+          {selectedFormat === 'csv' && (
+            <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
+              <input
+                type="checkbox"
+                checked={includeProgress}
+                onChange={e => setIncludeProgress(e.target.checked)}
+                className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+              />
+              <div className="flex-1">
+                <span className="font-semibold text-gray-900">
+                  {t('exportModal.includeProgress')}
+                </span>
+                <p className="text-xs text-gray-600">{t('exportModal.includeProgressDesc')}</p>
+              </div>
+            </label>
+          )}
+
+          {/* Format Preview */}
+          <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
+            <p className="text-sm font-bold text-gray-700 mb-2">{t('exportModal.previewTitle')}</p>
+            <div className="bg-white border border-gray-200 rounded-lg p-3 font-mono text-xs text-gray-600 overflow-x-auto">
+              {selectedFormat === 'csv' ? (
+                <div>
+                  <div className="text-gray-400">
+                    {includeProgress
+                      ? 'Front,Back,Context,Status,Ease Factor,Interval'
+                      : 'Front,Back,Context'}
+                  </div>
+                  <div>
+                    &quot;Ce este un verb?&quot;,&quot;O parte de vorbire&quot;,&quot;Exemplu: a
+                    merge&quot;
+                  </div>
+                  <div>
+                    &quot;Ce este un substantiv?&quot;,&quot;Un cuvânt care
+                    denumește&quot;,&quot;Exemplu: masă&quot;
+                  </div>
+                </div>
+              ) : (
+                <div>
+                  <div>
+                    Ce este un verb?{'\t'}O parte de vorbire{'\t'}Exemplu: a merge
+                  </div>
+                  <div>
+                    Ce este un substantiv?{'\t'}Un cuvânt care denumește{'\t'}Exemplu: masă
+                  </div>
+                </div>
+              )}
+            </div>
+            <p className="text-xs text-gray-500 mt-2">{t('exportModal.previewNote')}</p>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="p-6 border-t border-gray-100 flex gap-4">
+          <button
+            type="button"
+            onClick={onClose}
+            className="flex-1 bg-white border-2 border-gray-200 text-gray-700 font-bold py-3 rounded-xl hover:bg-gray-50 transition-colors"
+          >
+            {t('modal.cancel')}
+          </button>
+          <button
+            onClick={handleExport}
+            disabled={isExporting}
+            className="flex-1 bg-indigo-600 text-white font-bold py-3 rounded-xl hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2 disabled:opacity-50"
+          >
+            {isExporting ? (
+              <Loader2 className="animate-spin" size={20} />
+            ) : (
+              <>
+                <Download size={20} />
+                {t('exportModal.exportBtn')}
+              </>
+            )}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/pages/DeckList/GenerateCardsModal.tsx
+++ b/src/components/pages/DeckList/GenerateCardsModal.tsx
@@ -1,0 +1,622 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Difficulty, Card, DeckWithCards } from '../../../types';
+import { Plus, Upload, Sparkles, Loader2 } from 'lucide-react';
+import { generateDeckWithAI, importDeck } from '../../../api/decks';
+import { useToast } from '../../ui/Toast';
+
+interface GenerateCardsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mode: 'create' | 'edit' | 'generate';
+  existingDeck?: {
+    id: string;
+    title: string;
+    subject: string;
+    difficulty: Difficulty;
+  } | null;
+  onAddDeck: (deck: DeckWithCards) => void;
+  onEditDeck: (deck: DeckWithCards) => void;
+  decks: Array<{ id: string; title: string; subject: string; difficulty: Difficulty }>;
+}
+
+export const GenerateCardsModal: React.FC<GenerateCardsModalProps> = ({
+  isOpen,
+  onClose,
+  mode,
+  existingDeck,
+  onAddDeck,
+  onEditDeck,
+  decks,
+}) => {
+  const { t, i18n } = useTranslation('decks');
+  const toast = useToast();
+
+  // Form State
+  const [title, setTitle] = useState('');
+  const [subject, setSubject] = useState('Limba Română');
+  const [difficulty, setDifficulty] = useState<Difficulty>('A2');
+  const [importMode, setImportMode] = useState<'manual' | 'ai' | 'file'>('ai');
+  const [numberOfCards, setNumberOfCards] = useState(10);
+  const [selectedCardTypes, setSelectedCardTypes] = useState<
+    Array<'standard' | 'quiz' | 'type-answer'>
+  >(['standard', 'quiz', 'type-answer']);
+  const [selectedLanguage, setSelectedLanguage] = useState('ro');
+  const [extraContext, setExtraContext] = useState('');
+  const [isGenerating, setIsGenerating] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [fileContent, setFileContent] = useState<string>('');
+
+  // Loading messages for "The Dealer's Table" loading state
+  const dealerMessages = t('loading.dealerMessages', { returnObjects: true }) as string[];
+  const [currentMessageIndex, setCurrentMessageIndex] = useState(0);
+
+  // Available languages with flags
+  const languages = useMemo(
+    () => [
+      { code: 'ro', name: 'Română', flag: '🇷🇴' },
+      { code: 'en', name: 'English', flag: '🇬🇧' },
+      { code: 'it', name: 'Italiano', flag: '🇮🇹' },
+    ],
+    []
+  );
+
+  // Rotate loading messages every 3 seconds
+  useEffect(() => {
+    if (!isGenerating) return;
+
+    const interval = setInterval(() => {
+      setCurrentMessageIndex(prev => (prev + 1) % dealerMessages.length);
+    }, 3000);
+
+    return () => clearInterval(interval);
+  }, [isGenerating, dealerMessages.length]);
+
+  // Reset form when modal opens
+  useEffect(() => {
+    if (isOpen) {
+      if (mode === 'edit' && existingDeck) {
+        setTitle(existingDeck.title);
+        setSubject(existingDeck.subject);
+        setDifficulty(existingDeck.difficulty);
+      } else if (mode === 'generate' && existingDeck) {
+        setTitle(existingDeck.title || '');
+        setSubject(existingDeck.subject);
+        setDifficulty(existingDeck.difficulty);
+        setImportMode('ai');
+        setNumberOfCards(10);
+        setSelectedCardTypes(['standard', 'quiz', 'type-answer']);
+      } else {
+        setTitle('');
+        setSubject('Limba Română');
+        setDifficulty('A2');
+        setImportMode('ai');
+        setNumberOfCards(10);
+        setSelectedCardTypes(['standard', 'quiz', 'type-answer']);
+      }
+
+      // Default to current app language
+      const currentLang = i18n.language?.split('-')[0] || 'ro';
+      setSelectedLanguage(['ro', 'en', 'it'].includes(currentLang) ? currentLang : 'ro');
+      setExtraContext('');
+      setSelectedFile(null);
+      setFileContent('');
+    }
+  }, [isOpen, mode, existingDeck, i18n.language]);
+
+  const toggleCardType = (type: 'standard' | 'quiz' | 'type-answer') => {
+    setSelectedCardTypes(prev => {
+      if (prev.includes(type)) {
+        // Don't allow deselecting if it's the last selected type
+        if (prev.length === 1) return prev;
+        return prev.filter(t => t !== type);
+      } else {
+        return [...prev, type];
+      }
+    });
+  };
+
+  const handleFileSelect = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    setSelectedFile(file);
+
+    try {
+      const content = await file.text();
+      setFileContent(content);
+    } catch (error) {
+      console.error('Error reading file:', error);
+      toast.error(t('toast.fileReadError'));
+    }
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setIsGenerating(true);
+
+    try {
+      if (mode === 'edit' && existingDeck) {
+        // EDIT MODE (metadata only - no cards)
+        const existingDeckData = decks.find(d => d.id === existingDeck.id);
+        if (existingDeckData) {
+          const updatedDeck: DeckWithCards = {
+            ...existingDeckData,
+            id: existingDeck.id,
+            ownerId: '',
+            title,
+            subject,
+            topic: title,
+            difficulty,
+            isPublic: false,
+            tags: [],
+            cards: [],
+            totalCards: 0,
+            masteredCards: 0,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+          onEditDeck(updatedDeck);
+        }
+      } else if (mode === 'generate' && existingDeck) {
+        // GENERATE CARDS FOR EXISTING DECK
+        const newCards: Card[] = [];
+
+        if (importMode === 'ai') {
+          const response = await generateDeckWithAI(
+            subject,
+            title,
+            difficulty,
+            numberOfCards,
+            selectedCardTypes,
+            selectedLanguage,
+            extraContext || undefined
+          );
+          if (response.success && response.data) {
+            newCards.push(
+              ...response.data.map((card, index) => ({
+                ...card,
+                id: `ai-${Date.now()}-${index}`,
+                deckId: existingDeck.id,
+                position: index,
+                createdAt: new Date().toISOString(),
+                updatedAt: new Date().toISOString(),
+              }))
+            );
+          } else {
+            toast.error(response.error?.message || t('toast.generationError'));
+            setIsGenerating(false);
+            return;
+          }
+        }
+
+        const existingDeckData = decks.find(d => d.id === existingDeck.id);
+        if (existingDeckData) {
+          const updatedDeck: DeckWithCards = {
+            ...existingDeckData,
+            id: existingDeck.id,
+            ownerId: '',
+            topic: title,
+            isPublic: false,
+            tags: [],
+            cards: newCards,
+            totalCards: newCards.length,
+            masteredCards: 0,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+          onEditDeck(updatedDeck);
+        }
+      } else {
+        // CREATE MODE
+        if (importMode === 'ai') {
+          const response = await generateDeckWithAI(
+            subject,
+            title,
+            difficulty,
+            numberOfCards,
+            selectedCardTypes,
+            selectedLanguage,
+            extraContext || undefined
+          );
+
+          if (response.success && response.data) {
+            const newCards = response.data.map((card, index) => ({
+              ...card,
+              id: `ai-${Date.now()}-${index}`,
+              deckId: `d-${Date.now()}`,
+              position: index,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            }));
+
+            const newDeck: DeckWithCards = {
+              id: `d-${Date.now()}`,
+              ownerId: '',
+              title,
+              subject,
+              topic: title,
+              difficulty,
+              isPublic: false,
+              tags: [],
+              cards: newCards,
+              totalCards: newCards.length,
+              masteredCards: 0,
+              createdAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
+            };
+            onAddDeck(newDeck);
+          } else {
+            toast.error(response.error?.message || t('toast.generationError'));
+            setIsGenerating(false);
+            return;
+          }
+        } else if (importMode === 'file' && fileContent) {
+          // Import from file
+          const format = selectedFile?.name.endsWith('.csv') ? 'csv' : 'txt';
+          const response = await importDeck({
+            format,
+            data: fileContent,
+            title: title || undefined,
+            subject: subject || undefined,
+            difficulty: difficulty || undefined,
+          });
+
+          if (response.success && response.data) {
+            toast.success(t('toast.importSuccess', { count: response.data.cardsImported }));
+            // Reload to get the new deck
+            window.location.reload();
+            return;
+          } else {
+            toast.error(response.error?.message || t('toast.importError'));
+            setIsGenerating(false);
+            return;
+          }
+        } else if (importMode === 'manual') {
+          // Create empty deck
+          const newDeck: DeckWithCards = {
+            id: `d-${Date.now()}`,
+            ownerId: '',
+            title,
+            subject,
+            topic: title,
+            difficulty,
+            isPublic: false,
+            tags: [],
+            cards: [],
+            totalCards: 0,
+            masteredCards: 0,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+          onAddDeck(newDeck);
+        }
+      }
+
+      setIsGenerating(false);
+      onClose();
+    } catch (error) {
+      console.error('Error in form submission:', error);
+      toast.error(t('toast.generationError'));
+      setIsGenerating(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div className="fixed inset-0 bg-black/50 z-[60] flex items-center justify-center p-4 backdrop-blur-sm">
+      <div className="bg-white rounded-3xl w-full max-w-md max-h-[90vh] overflow-y-auto p-8 shadow-2xl animate-scale-up relative">
+        {/* "The Dealer's Table" Loading Overlay */}
+        {isGenerating && (
+          <div className="absolute inset-0 bg-gradient-to-br from-indigo-900/95 to-purple-900/95 rounded-3xl flex flex-col items-center justify-center z-50 backdrop-blur-sm">
+            {/* Juggling Cards Animation */}
+            <div className="relative w-32 h-32 mb-8">
+              <div className="absolute inset-0 flex items-center justify-center">
+                <div className="absolute animate-juggle-1">
+                  <div className="w-16 h-24 bg-gradient-to-br from-white to-gray-100 rounded-lg shadow-2xl border-2 border-gray-200 flex items-center justify-center text-3xl font-bold text-indigo-600">
+                    A
+                  </div>
+                </div>
+                <div className="absolute animate-juggle-2" style={{ animationDelay: '0.33s' }}>
+                  <div className="w-16 h-24 bg-gradient-to-br from-white to-gray-100 rounded-lg shadow-2xl border-2 border-gray-200 flex items-center justify-center text-3xl font-bold text-purple-600">
+                    K
+                  </div>
+                </div>
+                <div className="absolute animate-juggle-3" style={{ animationDelay: '0.66s' }}>
+                  <div className="w-16 h-24 bg-gradient-to-br from-white to-gray-100 rounded-lg shadow-2xl border-2 border-gray-200 flex items-center justify-center text-3xl font-bold text-pink-600">
+                    Q
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            {/* Dynamic Rotating Messages */}
+            <p className="text-white text-center font-semibold text-base px-8 max-w-sm leading-relaxed animate-fade-in">
+              {dealerMessages[currentMessageIndex]}
+            </p>
+
+            {/* Loading spinner */}
+            <Loader2 className="text-white animate-spin mt-6" size={24} />
+          </div>
+        )}
+
+        <h2 className="text-2xl font-bold mb-6 text-gray-900">
+          {mode === 'edit'
+            ? t('modal.editDeck')
+            : mode === 'generate'
+              ? t('modal.generateCards')
+              : t('modal.newDeck')}
+        </h2>
+
+        <form onSubmit={handleSubmit} className="space-y-6">
+          {/* Row 1: Subject (2/3) + Language (1/3) */}
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+            <div className="sm:col-span-2">
+              <label className="block text-sm font-bold text-gray-700 mb-2">
+                {t('modal.subject')}
+              </label>
+              <select
+                className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
+                value={subject}
+                onChange={e => setSubject(e.target.value)}
+              >
+                <option>Limba Română</option>
+                <option>Matematică</option>
+                <option>Istorie</option>
+                <option>Geografie</option>
+                <option>Engleză</option>
+              </select>
+            </div>
+            <div>
+              <label className="block text-sm font-bold text-gray-700 mb-2">
+                {t('modal.language')}
+              </label>
+              <select
+                className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
+                value={selectedLanguage}
+                onChange={e => setSelectedLanguage(e.target.value)}
+              >
+                {languages.map(lang => (
+                  <option key={lang.code} value={lang.code}>
+                    {lang.flag} {lang.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+
+          {/* Row 2: Title/Topic (full width) */}
+          <div>
+            <label className="block text-sm font-bold text-gray-700 mb-2">
+              {t('modal.titleLabel')}
+            </label>
+            <input
+              type="text"
+              className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
+              placeholder={t('modal.titlePlaceholder')}
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              required
+            />
+          </div>
+
+          {mode !== 'edit' && (
+            <>
+              {/* Row 3: Number of Cards (50%) + Difficulty (50%) */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-bold text-gray-700 mb-2">
+                    {importMode === 'ai' ? t('modal.numberOfCardsAI') : t('modal.numberOfCards')}
+                  </label>
+                  <input
+                    type="number"
+                    min="5"
+                    max="50"
+                    value={numberOfCards}
+                    onChange={e => setNumberOfCards(parseInt(e.target.value) || 10)}
+                    className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors disabled:opacity-50"
+                    disabled={importMode !== 'ai'}
+                  />
+                  <p className="text-xs text-gray-500 mt-1">
+                    {importMode === 'ai'
+                      ? t('modal.cardsRecommendation')
+                      : t('modal.cardsFromFile')}
+                  </p>
+                </div>
+                <div>
+                  <label className="block text-sm font-bold text-gray-700 mb-2">
+                    {t('modal.difficultyLabel')}
+                  </label>
+                  <select
+                    className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors"
+                    value={difficulty}
+                    onChange={e => setDifficulty(e.target.value as Difficulty)}
+                  >
+                    <option value="A1">A1 - {t('difficulty.A1')}</option>
+                    <option value="A2">A2 - {t('difficulty.A2')}</option>
+                    <option value="B1">B1 - {t('difficulty.B1')}</option>
+                    <option value="B2">B2 - {t('difficulty.B2')}</option>
+                    <option value="C1">C1 - {t('difficulty.C1')}</option>
+                  </select>
+                </div>
+              </div>
+
+              {mode === 'create' && (
+                <div className="pt-2">
+                  <label className="block text-sm font-bold text-gray-700 mb-2">
+                    {t('modal.creationMethod')}
+                  </label>
+                  <div className="grid grid-cols-3 gap-3">
+                    <button
+                      type="button"
+                      onClick={() => setImportMode('ai')}
+                      className={`p-3 rounded-xl border-2 text-sm flex flex-col items-center gap-1 font-bold transition-all ${
+                        importMode === 'ai'
+                          ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                          : 'border-gray-100 text-gray-500 hover:bg-gray-50'
+                      }`}
+                    >
+                      <Sparkles size={20} /> {t('modal.aiAuto')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setImportMode('file')}
+                      className={`p-3 rounded-xl border-2 text-sm flex flex-col items-center gap-1 font-bold transition-all ${
+                        importMode === 'file'
+                          ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                          : 'border-gray-100 text-gray-500 hover:bg-gray-50'
+                      }`}
+                    >
+                      <Upload size={20} /> {t('modal.import')}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setImportMode('manual')}
+                      className={`p-3 rounded-xl border-2 text-sm flex flex-col items-center gap-1 font-bold transition-all ${
+                        importMode === 'manual'
+                          ? 'bg-indigo-50 border-indigo-500 text-indigo-700'
+                          : 'border-gray-100 text-gray-500 hover:bg-gray-50'
+                      }`}
+                    >
+                      <Plus size={20} /> {t('modal.manual')}
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {importMode === 'ai' && (
+                <>
+                  <div>
+                    <label className="block text-sm font-bold text-gray-700 mb-3">
+                      {t('modal.cardTypes')}
+                    </label>
+                    <div className="space-y-2">
+                      <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
+                        <input
+                          type="checkbox"
+                          checked={selectedCardTypes.includes('standard')}
+                          onChange={() => toggleCardType('standard')}
+                          className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        />
+                        <div className="flex-1">
+                          <span className="font-semibold text-gray-900">{t('modal.standard')}</span>
+                          <p className="text-xs text-gray-600">{t('modal.standardDesc')}</p>
+                        </div>
+                      </label>
+
+                      <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
+                        <input
+                          type="checkbox"
+                          checked={selectedCardTypes.includes('quiz')}
+                          onChange={() => toggleCardType('quiz')}
+                          className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        />
+                        <div className="flex-1">
+                          <span className="font-semibold text-gray-900">{t('modal.quiz')}</span>
+                          <p className="text-xs text-gray-600">{t('modal.quizDesc')}</p>
+                        </div>
+                      </label>
+
+                      <label className="flex items-center gap-3 cursor-pointer p-3 bg-gray-50 rounded-xl hover:bg-gray-100 transition-colors">
+                        <input
+                          type="checkbox"
+                          checked={selectedCardTypes.includes('type-answer')}
+                          onChange={() => toggleCardType('type-answer')}
+                          className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                        />
+                        <div className="flex-1">
+                          <span className="font-semibold text-gray-900">
+                            {t('modal.typeAnswer')}
+                          </span>
+                          <p className="text-xs text-gray-600">{t('modal.typeAnswerDesc')}</p>
+                        </div>
+                      </label>
+                    </div>
+                    <p className="text-xs text-gray-500 mt-2">{t('modal.deselectCardType')}</p>
+                  </div>
+
+                  {/* Extra Context textarea */}
+                  <div>
+                    <label className="block text-sm font-bold text-gray-700 mb-2">
+                      {t('modal.extraContext')}
+                    </label>
+                    <textarea
+                      className="w-full border-2 border-gray-100 bg-gray-50 rounded-xl p-3 font-medium outline-none focus:border-indigo-500 transition-colors min-h-[120px] resize-y"
+                      placeholder={t('modal.extraContextPlaceholder')}
+                      value={extraContext}
+                      onChange={e => setExtraContext(e.target.value)}
+                      maxLength={2000}
+                    />
+                    <p className="text-xs text-gray-500 mt-1">{t('modal.extraContextHelper')}</p>
+                  </div>
+                </>
+              )}
+
+              {importMode === 'file' && mode === 'create' && (
+                <div className="space-y-4">
+                  <div className="border-2 border-dashed border-gray-300 rounded-xl p-6 text-center bg-gray-50">
+                    <input
+                      type="file"
+                      accept=".txt,.csv"
+                      onChange={handleFileSelect}
+                      className="w-full text-sm text-gray-500"
+                    />
+                    <p className="text-xs text-gray-400 mt-2 font-medium">
+                      {t('modal.fileImport')}
+                    </p>
+                    {selectedFile && (
+                      <p className="text-sm text-green-600 mt-2 font-medium">
+                        {t('modal.fileSelected', { name: selectedFile.name })}
+                      </p>
+                    )}
+                  </div>
+                  <div className="bg-blue-50 border border-blue-200 rounded-xl p-4">
+                    <p className="text-sm font-bold text-blue-800 mb-2">
+                      {t('modal.importFormatTitle')}
+                    </p>
+                    <div className="text-xs text-blue-700 space-y-1">
+                      <p>
+                        <strong>CSV:</strong> {t('modal.importFormatCSV')}
+                      </p>
+                      <p>
+                        <strong>TXT:</strong> {t('modal.importFormatTXT')}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              )}
+            </>
+          )}
+
+          <div className="flex gap-4 pt-4">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 bg-white border-2 border-gray-200 text-gray-700 font-bold py-3 rounded-xl hover:bg-gray-50 transition-colors"
+            >
+              {t('modal.cancel')}
+            </button>
+            <button
+              type="submit"
+              disabled={
+                isGenerating || (importMode === 'file' && !fileContent && mode === 'create')
+              }
+              className="flex-1 bg-gray-900 text-white font-bold py-3 rounded-xl hover:bg-gray-800 transition-colors flex justify-center items-center gap-2 shadow-lg hover:-translate-y-1 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {isGenerating ? (
+                <Loader2 className="animate-spin" />
+              ) : mode === 'edit' ? (
+                t('modal.save')
+              ) : mode === 'generate' ? (
+                t('modal.generateCardsBtn')
+              ) : (
+                t('modal.createDeck')
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
BREAKING DOWN:
- Extract GenerateCardsModal into separate component (~500 lines)
- Extract EditCardsModal into separate component (~300 lines)
- Create ExportModal for exporting deck cards as CSV/TXT

NEW FEATURES:
- Export deck cards to CSV or TXT format from deck menu
- CSV export optionally includes learning progress data
- Format preview shows sample output before export
- File import now properly processes uploaded CSV/TXT files

IMPROVEMENTS:
- DeckList.tsx reduced from 1336 lines to 472 lines
- Better separation of concerns with modular components
- Each modal handles its own state and logic
- Consistent styling and UX across all modals

TRANSLATIONS:
- Added export modal translations (en, ro, it)
- Added import format help text
- Added toast messages for export/import success/error