### PR TITLE
fix(export/import): fix UTF-8 encoding and add card type support

### DIFF
--- a/src/api/decks.ts
+++ b/src/api/decks.ts
@@ -106,7 +106,18 @@ export async function generateDeckWithAI(
 
 // Helper to download exported file
 export function downloadExportedDeck(fileName: string, content: string, mimeType: string) {
-  const blob = new Blob([atob(content)], { type: mimeType });
+  // Decode base64 to binary, then convert to UTF-8 properly
+  const binaryString = atob(content);
+  const bytes = new Uint8Array(binaryString.length);
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i);
+  }
+  const decoder = new TextDecoder('utf-8');
+  const decodedContent = decoder.decode(bytes);
+
+  // Add BOM for UTF-8 to ensure Excel and other apps recognize encoding
+  const bom = '\uFEFF';
+  const blob = new Blob([bom + decodedContent], { type: `${mimeType};charset=utf-8` });
   const url = URL.createObjectURL(blob);
   const a = document.createElement('a');
   a.href = url;

--- a/src/components/pages/DeckList/ExportModal.tsx
+++ b/src/components/pages/DeckList/ExportModal.tsx
@@ -127,30 +127,28 @@ export const ExportModal: React.FC<ExportModalProps> = ({ isOpen, deckId, deckTi
           {/* Format Preview */}
           <div className="bg-gray-50 border border-gray-200 rounded-xl p-4">
             <p className="text-sm font-bold text-gray-700 mb-2">{t('exportModal.previewTitle')}</p>
-            <div className="bg-white border border-gray-200 rounded-lg p-3 font-mono text-xs text-gray-600 overflow-x-auto">
+            <div className="bg-white border border-gray-200 rounded-lg p-3 font-mono text-xs text-gray-600 overflow-x-auto whitespace-nowrap">
               {selectedFormat === 'csv' ? (
-                <div>
+                <div className="space-y-1">
                   <div className="text-gray-400">
                     {includeProgress
-                      ? 'Front,Back,Context,Status,Ease Factor,Interval'
-                      : 'Front,Back,Context'}
+                      ? 'Front,Back,Context,Type,Options,CorrectOptionIndex,Status,EaseFactor,Interval'
+                      : 'Front,Back,Context,Type,Options,CorrectOptionIndex'}
                   </div>
-                  <div>
-                    &quot;Ce este un verb?&quot;,&quot;O parte de vorbire&quot;,&quot;Exemplu: a
-                    merge&quot;
+                  <div className="text-green-700">
+                    &quot;Ce este un verb?&quot;,&quot;O parte de vorbire&quot;,,standard,,
                   </div>
-                  <div>
-                    &quot;Ce este un substantiv?&quot;,&quot;Un cuvânt care
-                    denumește&quot;,&quot;Exemplu: masă&quot;
+                  <div className="text-blue-700">
+                    &quot;Câte litere are cheag?&quot;,&quot;5&quot;,,quiz,&quot;4|5|6|7&quot;,1
                   </div>
                 </div>
               ) : (
-                <div>
-                  <div>
-                    Ce este un verb?{'\t'}O parte de vorbire{'\t'}Exemplu: a merge
+                <div className="space-y-1">
+                  <div className="text-green-700">
+                    Ce este un verb?{'  →  '}O parte de vorbire{'  →  '}context{'  →  '}standard
                   </div>
-                  <div>
-                    Ce este un substantiv?{'\t'}Un cuvânt care denumește{'\t'}Exemplu: masă
+                  <div className="text-blue-700">
+                    Câte litere?{'  →  '}5{'  →  '}context{'  →  '}quiz{'  →  '}4|5|6|7{'  →  '}1
                   </div>
                 </div>
               )}


### PR DESCRIPTION
- Fix UTF-8 encoding in downloadExportedDeck by using TextDecoder with BOM
- Export now includes card type, options, and correctOptionIndex for quiz cards
- Import now detects and properly sets card types (standard, quiz, type-answer)
- Updated CSV/TXT export formats to include all quiz card data
- Updated ExportModal preview to show new format with card types