### PR TITLE
feat(decks): add 'Add Cards' button and fix import reload

### DIFF
--- a/public/locales/en/decks.json
+++ b/public/locales/en/decks.json
@@ -9,7 +9,10 @@
     "inStudy": "{{count}} in study",
     "mastered": "{{count}} mastered",
     "generate": "Generate",
+    "generateShort": "Generate AI",
+    "addCards": "Add",
     "createSession": "Create session",
+    "session": "Session",
     "addCardsFirst": "Add cards first"
   },
   "menu": {
@@ -33,6 +36,7 @@
   "modal": {
     "editDeck": "Edit Deck",
     "generateCards": "Generate Cards",
+    "addCards": "Add Cards",
     "newDeck": "New Deck",
     "subject": "Subject",
     "titleLabel": "Title / Topic",
@@ -43,6 +47,7 @@
     "cardsRecommendation": "Recommendation: 10-20 cards for efficient sessions",
     "cardsFromFile": "Number of cards will depend on the imported file",
     "creationMethod": "Creation Method",
+    "addMethod": "Add Method",
     "aiAuto": "AI Auto",
     "import": "Import",
     "manual": "Manual",
@@ -62,6 +67,7 @@
     "cancel": "Cancel",
     "save": "Save",
     "generateCardsBtn": "Generate Cards",
+    "addCardsBtn": "Add Cards",
     "createDeck": "Create Deck",
     "language": "Language",
     "extraContext": "Extra Context / Examples (Optional)",
@@ -121,7 +127,9 @@
     "exportError": "Error exporting cards",
     "importSuccess": "Imported {{count}} cards successfully",
     "importError": "Error importing cards",
-    "fileReadError": "Error reading file"
+    "fileReadError": "Error reading file",
+    "cardsAdded": "Added {{count}} cards successfully",
+    "openEditCards": "Opening card editor..."
   },
   "guestPrompt": {
     "createDeck": {
@@ -131,6 +139,10 @@
     "aiGeneration": {
       "title": "Premium Feature",
       "message": "AI card generation is only available for users with an account. Create a free account to unlock this feature!"
+    },
+    "addCards": {
+      "title": "Create a free account",
+      "message": "To add cards to decks, create a free account!"
     }
   }
 }

--- a/public/locales/it/decks.json
+++ b/public/locales/it/decks.json
@@ -9,7 +9,10 @@
     "inStudy": "{{count}} in studio",
     "mastered": "{{count}} masterizzate",
     "generate": "Genera",
+    "generateShort": "Genera AI",
+    "addCards": "Aggiungi",
     "createSession": "Crea sessione",
+    "session": "Sessione",
     "addCardsFirst": "Aggiungi prima le carte"
   },
   "menu": {
@@ -33,6 +36,7 @@
   "modal": {
     "editDeck": "Modifica Mazzo",
     "generateCards": "Genera Carte",
+    "addCards": "Aggiungi Carte",
     "newDeck": "Nuovo Mazzo",
     "subject": "Materia",
     "titleLabel": "Titolo / Argomento",
@@ -43,6 +47,7 @@
     "cardsRecommendation": "Raccomandazione: 10-20 carte per sessioni efficaci",
     "cardsFromFile": "Il numero di carte dipenderà dal file importato",
     "creationMethod": "Metodo di Creazione",
+    "addMethod": "Metodo di Aggiunta",
     "aiAuto": "AI Auto",
     "import": "Importa",
     "manual": "Manuale",
@@ -62,6 +67,7 @@
     "cancel": "Annulla",
     "save": "Salva",
     "generateCardsBtn": "Genera Carte",
+    "addCardsBtn": "Aggiungi Carte",
     "createDeck": "Crea Mazzo",
     "language": "Lingua",
     "extraContext": "Contesto Extra / Esempi (Opzionale)",
@@ -121,7 +127,9 @@
     "exportError": "Errore nell'esportazione delle carte",
     "importSuccess": "{{count}} carte importate con successo",
     "importError": "Errore nell'importazione delle carte",
-    "fileReadError": "Errore nella lettura del file"
+    "fileReadError": "Errore nella lettura del file",
+    "cardsAdded": "{{count}} carte aggiunte con successo",
+    "openEditCards": "Apertura editor carte..."
   },
   "guestPrompt": {
     "createDeck": {
@@ -131,6 +139,10 @@
     "aiGeneration": {
       "title": "Funzione Premium",
       "message": "La generazione di carte con AI è disponibile solo per gli utenti con account. Crea un account gratuito per sbloccare questa funzione!"
+    },
+    "addCards": {
+      "title": "Crea un account gratuito",
+      "message": "Per aggiungere carte ai mazzi, crea un account gratuito!"
     }
   }
 }

--- a/public/locales/ro/decks.json
+++ b/public/locales/ro/decks.json
@@ -9,7 +9,10 @@
     "inStudy": "{{count}} în studiu",
     "mastered": "{{count}} învățate",
     "generate": "Generează",
+    "generateShort": "Generează AI",
+    "addCards": "Adaugă",
     "createSession": "Creează sesiune",
+    "session": "Sesiune",
     "addCardsFirst": "Adaugă carduri mai întâi"
   },
   "menu": {
@@ -33,6 +36,7 @@
   "modal": {
     "editDeck": "Editează Deck",
     "generateCards": "Generează Carduri",
+    "addCards": "Adaugă Carduri",
     "newDeck": "Deck Nou",
     "subject": "Subiect",
     "titleLabel": "Titlu / Tematică",
@@ -43,6 +47,7 @@
     "cardsRecommendation": "Recomandare: 10-20 carduri pentru sesiuni eficiente",
     "cardsFromFile": "Numărul de carduri va depinde de fișierul importat",
     "creationMethod": "Metodă Creare",
+    "addMethod": "Metodă Adăugare",
     "aiAuto": "AI Auto",
     "import": "Import",
     "manual": "Manual",
@@ -62,6 +67,7 @@
     "cancel": "Anulează",
     "save": "Salvează",
     "generateCardsBtn": "Generează Carduri",
+    "addCardsBtn": "Adaugă Carduri",
     "createDeck": "Creează Deck",
     "language": "Limbă",
     "extraContext": "Context Suplimentar / Exemple (Opțional)",
@@ -132,7 +138,9 @@
     "exportError": "Eroare la exportarea cardurilor",
     "importSuccess": "{{count}} carduri importate cu succes",
     "importError": "Eroare la importarea cardurilor",
-    "fileReadError": "Eroare la citirea fișierului"
+    "fileReadError": "Eroare la citirea fișierului",
+    "cardsAdded": "{{count}} carduri adăugate cu succes",
+    "openEditCards": "Se deschide editorul de carduri..."
   },
   "guestPrompt": {
     "createDeck": {
@@ -142,6 +150,10 @@
     "aiGeneration": {
       "title": "Funcție Premium",
       "message": "Generarea de carduri cu AI este disponibilă doar pentru utilizatorii cu cont. Creează un cont gratuit pentru a debloca această funcție!"
+    },
+    "addCards": {
+      "title": "Creează un cont gratuit",
+      "message": "Pentru a adăuga carduri la deck-uri, creează un cont gratuit!"
     }
   }
 }

--- a/src/api/decks.ts
+++ b/src/api/decks.ts
@@ -56,6 +56,7 @@ export async function importDeck(data: {
   title?: string;
   subject?: string;
   difficulty?: string;
+  deckId?: string; // If provided, adds cards to existing deck
 }) {
   return api.post<{ deckId: string; cardsImported: number }>('/import/deck', data);
 }


### PR DESCRIPTION
Features:
- Add 'Add Cards' button to deck tiles (AI, import, manual)
- New 'addCards' mode in GenerateCardsModal
- Import cards to existing deck via deckId parameter
- Stay on MyDecks page after import (no reload)
- Close modal when clicking outside

Backend:
- Import API now supports optional deckId to add cards to existing deck
- Cards are appended with correct position

UI/UX:
- Three buttons on deck tiles: Generate AI, Add Cards, Session
- Compact button styling to fit three buttons

Translations:
- Added all new keys for ro, en, it locales