### PR TITLE
fix(study): correct animation visuals and prevent level-up infinite loop

### DIFF
--- a/src/components/study-session/animations/StreakCelebration.tsx
+++ b/src/components/study-session/animations/StreakCelebration.tsx
@@ -21,7 +21,7 @@ export const StreakCelebration: React.FC<StreakCelebrationProps> = ({ streak, on
   }, [onComplete]);
 
   return (
-    <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center pointer-events-none bg-black/20 backdrop-blur-sm">
+    <div className="absolute inset-0 z-50 flex flex-col items-center justify-center pointer-events-none">
       <div className="bg-white/95 backdrop-blur-md p-8 rounded-3xl shadow-2xl flex flex-col items-center animate-pop-in border-4 border-orange-400">
         <Trophy className="w-20 h-20 text-yellow-500 mb-4 animate-bounce" />
         <h2 className="text-4xl font-black text-gray-900 italic tracking-tighter drop-shadow-lg">

--- a/src/components/study-session/animations/XPFloatingAnimation.tsx
+++ b/src/components/study-session/animations/XPFloatingAnimation.tsx
@@ -19,7 +19,7 @@ export const XPFloatingAnimation: React.FC<XPFloatingAnimationProps> = ({ xp, on
     const timer = setTimeout(() => {
       setVisible(false);
       onAnimationEnd?.();
-    }, 1500); // Match animation duration
+    }, 2500); // Match animation duration
 
     return () => clearTimeout(timer);
   }, [onAnimationEnd]);
@@ -34,7 +34,7 @@ export const XPFloatingAnimation: React.FC<XPFloatingAnimationProps> = ({ xp, on
   const animation = (
     <div className="fixed top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 z-[9999] pointer-events-none">
       <div
-        className={`${color} font-black text-5xl animate-float-xp whitespace-nowrap drop-shadow-2xl`}
+        className={`${color} font-black text-2xl animate-float-xp whitespace-nowrap drop-shadow-2xl`}
       >
         {sign}
         {displayValue} XP

--- a/src/components/study-session/animations/animations.css
+++ b/src/components/study-session/animations/animations.css
@@ -1,22 +1,23 @@
 /* Study Session Animations */
 
-/* Floating XP Animation */
+/* Floating XP Animation - floats toward top-right (XP indicator) */
 @keyframes float-xp {
   0% {
     opacity: 1;
-    transform: translateY(0) scale(1);
+    transform: translate(0, 0) scale(1);
   }
-  50% {
-    transform: translateY(-30px) scale(1.2);
+  20% {
+    opacity: 1;
+    transform: translate(10px, -20px) scale(1.2);
   }
   100% {
     opacity: 0;
-    transform: translateY(-60px) scale(1);
+    transform: translate(120px, -200px) scale(0.5);
   }
 }
 
 .animate-float-xp {
-  animation: float-xp 1.5s ease-out forwards;
+  animation: float-xp 2.5s cubic-bezier(0.4, 0, 0.2, 1) forwards;
 }
 
 /* Pop In Animation */


### PR DESCRIPTION
a) XP Animation: trajectory changed from straight-up to right-up
   (toward XP indicator), font reduced 50% (text-5xl→text-2xl),
   duration increased 70% (1.5s→2.5s).

b) Streak Celebration: changed from fixed viewport positioning to
   absolute within card container. The sidebar offset caused viewport
   centering to appear left-down relative to the card. Now uses
   absolute inset-0 inside the card area div (made relative).

c) Level-Up infinite loop: after level-up, updateUser() is async
   (React state), so the user object stays stale on the next answer.
   Meanwhile sessionXP keeps growing, so the threshold check re-fires.
   Fix: two synchronous refs track post-level-up user XP state and
   the sessionXP consumed at each level-up. checkLevelUp() reads
   refs instead of stale React state, and only counts XP earned
   since the last level-up toward the next threshold.

https://claude.ai/code/session_018A93kX3m5MUXCKFeH75z8o