### PR TITLE
fix(daily-challenges): use last_activity_at instead of started_at for…

### DIFF
--- a/server/routes/dailyChallenges.ts
+++ b/server/routes/dailyChallenges.ts
@@ -49,7 +49,7 @@ router.get('/today', authenticateToken, async (req, res) => {
       `SELECT status, correct_count, duration_seconds, answers
        FROM study_sessions
        WHERE user_id = $1
-         AND DATE(started_at) = $2`,
+         AND DATE(last_activity_at) = $2`,
       [userId, today]
     );
 
@@ -195,7 +195,7 @@ router.post('/claim-reward', authenticateToken, async (req, res) => {
       // CRITICAL FIX: Include both completed AND active sessions (match /today logic)
       // Active sessions have correct_count = NULL but have answers in JSON field
       const sessionsResult = await query(
-        'SELECT status, correct_count, answers FROM study_sessions WHERE user_id = $1 AND DATE(started_at) = $2',
+        'SELECT status, correct_count, answers FROM study_sessions WHERE user_id = $1 AND DATE(last_activity_at) = $2',
         [userId, today]
       );
       let totalCorrectAnswers = 0;
@@ -217,7 +217,7 @@ router.post('/claim-reward', authenticateToken, async (req, res) => {
     } else if (challengeId === 'time') {
       // Aggregate time from all sessions today
       const sessionsResult = await query(
-        'SELECT duration_seconds FROM study_sessions WHERE user_id = $1 AND DATE(started_at) = $2',
+        'SELECT duration_seconds FROM study_sessions WHERE user_id = $1 AND DATE(last_activity_at) = $2',
         [userId, today]
       );
       let totalTimeMinutes = 0;
@@ -232,7 +232,7 @@ router.post('/claim-reward', authenticateToken, async (req, res) => {
       // User's streak value is only updated after session completion, but we need to check
       // if TODAY's activity meets the requirement (even from active sessions)
       const sessionsResult = await query(
-        'SELECT status, correct_count, duration_seconds, answers FROM study_sessions WHERE user_id = $1 AND DATE(started_at) = $2',
+        'SELECT status, correct_count, duration_seconds, answers FROM study_sessions WHERE user_id = $1 AND DATE(last_activity_at) = $2',
         [userId, today]
       );
 
@@ -350,7 +350,7 @@ router.get('/activity-calendar', authenticateToken, async (req, res) => {
       `SELECT status, duration_seconds, answers
        FROM study_sessions
        WHERE user_id = $1
-         AND DATE(started_at) = $2
+         AND DATE(last_activity_at) = $2
          AND status = 'active'`,
       [userId, todayStr]
     );


### PR DESCRIPTION
… date filtering

Sessions created on a previous day but studied today were excluded from daily challenge progress because the query filtered by DATE(started_at). A session's started_at is set once at creation and never changes, so resuming an older session today wouldn't count toward today's challenges.

Changed all 5 queries in dailyChallenges.ts to filter by DATE(last_activity_at), which is updated to NOW() on every session save and completion. This correctly captures study activity regardless of when the session was originally created.

Affected routes:
- GET /today (main progress aggregation)
- POST /claim-reward (cards, time, and streak verification)
- GET /activity-calendar (today's active sessions)

https://claude.ai/code/session_018A93kX3m5MUXCKFeH75z8o