### PR TITLE
fix(study-sessions): persist level-up XP deduction to database

### DIFF
--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { useStudySessionsStore } from '../../store/studySessionsStore';
+import { useStudySessionsStore, setOnUserUpdateCallback } from '../../store/studySessionsStore';
 import { useAuth } from '../../store/AuthContext';
 import { StandardCard } from './cards/StandardCard';
 import { QuizCard } from './cards/QuizCard';
@@ -77,6 +77,21 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
   // sessionXPAtLastLevelUp: the sessionXP value when level-up last occurred,
   // so we only count XP earned *since* the last level-up toward the next threshold
   const sessionXPAtLastLevelUp = useRef(0);
+
+  // Wire user update callback so PUT responses can sync auth context
+  useEffect(() => {
+    setOnUserUpdateCallback(data => {
+      updateUser({
+        level: data.level,
+        currentXP: data.currentXP,
+        nextLevelXP: data.nextLevelXP,
+        totalXP: data.totalXP,
+      });
+    });
+    return () => {
+      setOnUserUpdateCallback(null);
+    };
+  }, [updateUser]);
 
   // Load session and enable auto-save on mount
   useEffect(() => {


### PR DESCRIPTION
The PUT /study-sessions/:id handler had three issues causing level-ups to not persist:

1. Used `100 * 1.2^(level-1)` for next-level threshold instead of the stored `next_level_xp` column. These values diverge at higher levels due to cumulative Math.floor rounding, so the server threshold was higher than the client's — level-ups never triggered server-side.

2. Never updated `users.next_level_xp` column even when a level-up occurred, leaving it stale in the database.

3. The POST /complete handler double-counted XP by adding session_xp to total_xp/current_xp, but PUT already added it incrementally.

Changes:
- PUT handler: read stored next_level_xp, use it for level-up check, persist all 4 columns (level, current_xp, next_level_xp, total_xp)
- PUT handler: return updated user data in response for frontend sync
- PUT handler: track xp_earned in daily_progress incrementally
- Complete handler: remove XP/level re-calculation (PUT handles it)
- Complete handler: remove xp_earned from daily_progress (PUT tracks it)
- Frontend: wire PUT response user data to auth context via callback

https://claude.ai/code/session_01VBNN29BztBkhwAZCsAxbgn