### PR TITLE
fix(study-sessions): sync XP on exit, reset on resume, smart card index

### DIFF
--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -53,6 +53,7 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
     sessionStartTime,
     totalActiveSeconds,
     perCardTimes,
+    syncProgress,
   } = useStudySessionsStore();
 
   // Animation state
@@ -124,9 +125,16 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
     }
   }, [answers, currentSession, showCompletionModal]);
 
+  // Handle back navigation - sync progress before leaving
+  const handleBack = async () => {
+    await syncProgress();
+    onBack();
+  };
+
   // Handle completion modal actions
   const handleSaveAndExit = async () => {
     setShowCompletionModal(false);
+    await syncProgress();
     onBack();
   };
 
@@ -271,7 +279,7 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
   const handleShuffle = () => {
     if (
       window.confirm(
-        'Sigur vrei să amesteci cardurile? Progresul (răspunsuri) va fi șters, dar XP-ul și streak-ul vor fi păstrate.'
+        'Sigur vrei să amesteci cardurile? Progresul (răspunsuri), XP-ul și streak-ul vor fi resetate.'
       )
     ) {
       shuffleCards();
@@ -282,7 +290,7 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
   const handleRestart = () => {
     if (
       window.confirm(
-        'Sigur vrei să restartezi sesiunea? Progresul (răspunsuri) va fi șters, dar XP-ul și streak-ul vor fi păstrate.'
+        'Sigur vrei să restartezi sesiunea? Progresul (răspunsuri), XP-ul și streak-ul vor fi resetate.'
       )
     ) {
       restartSession();
@@ -430,7 +438,7 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
         <div className="mb-8">
           <div className="flex items-center justify-between mb-4">
             <button
-              onClick={onBack}
+              onClick={handleBack}
               className="flex items-center gap-2 text-gray-600 hover:text-gray-900 font-medium transition-all active:scale-95"
             >
               <ArrowLeft size={20} />


### PR DESCRIPTION
- Sync progress before all exit paths (Înapoi button, Save & Exit modal)
- Reset sessionXP and streak to 0 on every session load/resume
- Compute smart start card index: first unanswered → first skipped → full reset
- Fix hint XP deduction to charge only once per card (track revealedHintCardIds)
- Restore hintRevealed state when navigating back to previously hinted cards
- Reset XP/streak on shuffle and restart (sync reset to backend)
- Update confirmation messages to reflect reset behavior

https://claude.ai/code/session_01VBNN29BztBkhwAZCsAxbgn