### PR TITLE
feat(sessions): exclude active session cards & round-robin card inter…

### DIFF
--- a/public/locales/en/session.json
+++ b/public/locales/en/session.json
@@ -30,6 +30,10 @@
       "excludeMastered": {
         "label": "Exclude mastered cards",
         "description": "Don't include cards with \"mastered\" status"
+      },
+      "excludeActiveSessions": {
+        "label": "Exclude active session cards",
+        "description": "Don't include cards already in an active session"
       }
     },
     "manual": {

--- a/public/locales/ro/session.json
+++ b/public/locales/ro/session.json
@@ -30,6 +30,10 @@
       "excludeMastered": {
         "label": "Exclude carduri învățate",
         "description": "Nu include carduri cu status \"mastered\""
+      },
+      "excludeActiveSessions": {
+        "label": "Exclude carduri din sesiuni active",
+        "description": "Nu include carduri deja alocate într-o sesiune activă"
       }
     },
     "manual": {

--- a/src/components/sessions/CreateSessionModal.tsx
+++ b/src/components/sessions/CreateSessionModal.tsx
@@ -36,6 +36,7 @@ const CreateSessionModal: React.FC<CreateSessionModalProps> = ({
   );
   const [cardCount, setCardCount] = useState(20);
   const [excludeMastered, setExcludeMastered] = useState(true);
+  const [excludeActiveSessionCards, setExcludeActiveSessionCards] = useState(false);
   const [deckCards, setDeckCards] = useState<Array<{ id: string; front: string }>>([]);
   const [selectedCardIds, setSelectedCardIds] = useState<string[]>([]);
   const [loadingCards, setLoadingCards] = useState(false);
@@ -94,6 +95,7 @@ const CreateSessionModal: React.FC<CreateSessionModalProps> = ({
       deckId: deck.id,
       selectionMethod,
       excludeMasteredCards: excludeMastered,
+      excludeActiveSessionCards,
     };
 
     if (selectionMethod === 'random' || selectionMethod === 'smart') {
@@ -230,13 +232,13 @@ const CreateSessionModal: React.FC<CreateSessionModalProps> = ({
           )}
 
           {/* Options */}
-          <div className="space-y-3">
-            <label className="flex items-center gap-3 cursor-pointer">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+            <label className="flex items-start gap-3 cursor-pointer">
               <input
                 type="checkbox"
                 checked={excludeMastered}
                 onChange={e => setExcludeMastered(e.target.checked)}
-                className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500"
+                className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 mt-0.5"
               />
               <div className="flex-1">
                 <span className="font-semibold text-gray-900">
@@ -244,6 +246,22 @@ const CreateSessionModal: React.FC<CreateSessionModalProps> = ({
                 </span>
                 <p className="text-xs text-gray-600">
                   {t('create.options.excludeMastered.description')}
+                </p>
+              </div>
+            </label>
+            <label className="flex items-start gap-3 cursor-pointer">
+              <input
+                type="checkbox"
+                checked={excludeActiveSessionCards}
+                onChange={e => setExcludeActiveSessionCards(e.target.checked)}
+                className="w-5 h-5 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500 mt-0.5"
+              />
+              <div className="flex-1">
+                <span className="font-semibold text-gray-900">
+                  {t('create.options.excludeActiveSessions.label')}
+                </span>
+                <p className="text-xs text-gray-600">
+                  {t('create.options.excludeActiveSessions.description')}
                 </p>
               </div>
             </label>

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -195,6 +195,7 @@ export interface CreateStudySessionRequest {
   cardCount?: number; // For 'random' and 'smart' methods
   selectedCardIds?: string[]; // For 'manual' method
   excludeMasteredCards?: boolean; // Default: true
+  excludeActiveSessionCards?: boolean; // Default: false - exclude cards already in active sessions
   title?: string; // Optional custom title
 }
 


### PR DESCRIPTION
…leaving

Feature 1: Add option to exclude cards already in user's active sessions
- New checkbox in CreateSessionModal alongside "Exclude mastered cards"
- Responsive layout: side-by-side on desktop, stacked on mobile
- Backend queries active session card IDs and filters them out
- Added excludeCardIds option to cardSelectionService

Feature 2: Round-robin card type interleaving
- Cards are reordered: standard → quiz → multiple-answer → type-answer → repeat
- Applied during session initialization for both authenticated and guest sessions
- Skips types that run out, continues with remaining types
- Added interleaveCardsByType function to cardSelectionService

https://claude.ai/code/session_01VBNN29BztBkhwAZCsAxbgn