### PR TITLE
fix(sessions): preserve card interleaving order & dynamic available c…

### DIFF
--- a/public/locales/en/session.json
+++ b/public/locales/en/session.json
@@ -53,7 +53,9 @@
     "errors": {
       "loadingCards": "Error loading cards",
       "selectAtLeastOne": "Select at least one card",
-      "creating": "Error creating session"
+      "creating": "Error creating session",
+      "noCardsAvailable": "No cards available with current filters",
+      "noCardsAvailableHint": "Try unchecking some filter options above to include more cards."
     }
   },
   "continue": "Continue",

--- a/public/locales/ro/session.json
+++ b/public/locales/ro/session.json
@@ -53,7 +53,9 @@
     "errors": {
       "loadingCards": "Eroare la încărcarea cardurilor",
       "selectAtLeastOne": "Selectează cel puțin un card",
-      "creating": "Eroare la crearea sesiunii"
+      "creating": "Eroare la crearea sesiunii",
+      "noCardsAvailable": "Nu există carduri disponibile cu filtrele selectate",
+      "noCardsAvailableHint": "Încearcă să debifezi unele opțiuni de filtrare de mai sus pentru a include mai multe carduri."
     }
   },
   "continue": "Continuă",

--- a/src/api/studySessions.ts
+++ b/src/api/studySessions.ts
@@ -10,6 +10,27 @@ import type {
 import type { StudySession, StudySessionWithData } from '../types/models';
 
 /**
+ * Get available card count for session creation (accounts for filters)
+ */
+export async function getAvailableCardCount(
+  deckId: string,
+  excludeMastered: boolean,
+  excludeActiveSessionCards: boolean
+) {
+  const params = new URLSearchParams({
+    deckId,
+    excludeMastered: String(excludeMastered),
+    excludeActiveSessionCards: String(excludeActiveSessionCards),
+  });
+  return api.get<{
+    totalCards: number;
+    masteredCount: number;
+    activeSessionCardCount: number;
+    availableCount: number;
+  }>(`/study-sessions/available-count?${params.toString()}`);
+}
+
+/**
  * Create a new study session
  */
 export async function createStudySession(request: CreateStudySessionRequest) {


### PR DESCRIPTION
…ount

Fix round-robin interleaving not taking effect:
- GET endpoints were re-sorting cards by position ASC, overriding the interleaved order stored in selected_card_ids
- Changed to ORDER BY array_position() to preserve stored card order
- Applied to both authenticated and guest session GET endpoints

Add dynamic available card count in CreateSessionModal:
- New GET /api/study-sessions/available-count endpoint computes exact available count accounting for mastered and active session exclusions
- Modal fetches count on mount and when filter checkboxes change
- Slider max and available count label update in real-time
- Start Session button disabled when no cards available

Improve error handling when all cards are excluded:
- Show amber warning box with descriptive message and hint to uncheck filters
- Added i18n keys for noCardsAvailable/noCardsAvailableHint (en + ro)

https://claude.ai/code/session_01VBNN29BztBkhwAZCsAxbgn