### PR TITLE
fix(tags): pass tags through deck management and auto-commit on blur

### DIFF
--- a/src/components/ui/TagInput.tsx
+++ b/src/components/ui/TagInput.tsx
@@ -141,7 +141,13 @@ export const TagInput: React.FC<TagInputProps> = ({
             onChange={handleInputChange}
             onKeyDown={handleKeyDown}
             onFocus={() => inputValue.trim() && updateSuggestions(inputValue)}
-            onBlur={() => setTimeout(() => setShowSuggestions(false), 200)}
+            onBlur={() => {
+              // Auto-commit typed text as a tag on blur
+              if (inputValue.trim()) {
+                addTag(inputValue);
+              }
+              setTimeout(() => setShowSuggestions(false), 200);
+            }}
             placeholder={tags.length === 0 ? placeholder : ''}
             className="flex-1 min-w-[80px] outline-none text-sm bg-transparent"
           />

--- a/src/hooks/useDecksManagement.ts
+++ b/src/hooks/useDecksManagement.ts
@@ -42,6 +42,7 @@ export function useDecksManagement() {
             type: c.type,
             options: c.options,
             correctOptionIndices: c.correctOptionIndices,
+            tags: c.tags,
           })),
         });
 
@@ -84,6 +85,7 @@ export function useDecksManagement() {
                 type: card.type,
                 options: card.options,
                 correctOptionIndices: card.correctOptionIndices,
+                tags: card.tags,
               });
             } catch (cardError) {
               console.error('Error adding card:', cardError);


### PR DESCRIPTION
- Add tags field to card mappings in useDecksManagement handleAddDeck and handleEditDeck so AI-generated tags are persisted to the database
- Add onBlur auto-commit in TagInput so typed text becomes a tag when the user clicks Save or Apply Tags without pressing Enter first

Fixes: AI tags not saved, edit save not persisting tags, bulk edit Apply Tags button staying disabled, and topic filter not appearing (since cards now actually have tags stored).

https://claude.ai/code/session_01PGeVU1P6UvJYnuodLhHD45