### PR TITLE
fix(standard-card): fix navigation bugs — Nu știu button, Arată on ba…

### DIFF
--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -316,8 +316,13 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
           setShowStreakCelebration(true);
         }
       }
+    } else if (previousStatus === 'correct' && !isCorrect) {
+      // Scenario B: User clicked "Știu" then "Nu știu" — downgrade to incorrect
+      // Allow changing from correct → incorrect (user realized they were wrong)
+      // No XP/streak update needed (anti-cheating: only downgrade allowed)
+      answerCard(currentCard.id, isCorrect);
     }
-    // Scenario B: Already answered (correct/incorrect) → Skip answerCard
+    // Scenario C: Already answered (incorrect→correct or same) → Skip answerCard
     // Local UI feedback in QuizCard will still show, but no XP/streak update
 
     // Auto-advance to next card after a short delay

--- a/src/components/study-session/cards/StandardCard.tsx
+++ b/src/components/study-session/cards/StandardCard.tsx
@@ -73,13 +73,16 @@ export const StandardCard: React.FC<StandardCardProps> = ({
   const handleShow = (e: React.MouseEvent) => {
     e.stopPropagation();
     setFrontAction('show');
-    onAnswer(false);
+    if (!hasAnswered) {
+      onAnswer(false);
+    }
     flipCard();
   };
 
   // Handle "Nu știu" button on back (change from correct to incorrect)
   const handleDontKnow = (e: React.MouseEvent) => {
     e.stopPropagation();
+    setFrontAction('show'); // Hide "Nu știu" button after clicking (answer is now incorrect)
     onAnswer(false);
   };
 
@@ -194,8 +197,8 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                   <ChevronLeft size={20} />
                 </button>
 
-                {/* Action buttons - only show if not answered */}
-                {!hasAnswered && (
+                {/* Action buttons */}
+                {!hasAnswered ? (
                   <div className="flex gap-2 flex-1 justify-center">
                     <button
                       onClick={handleKnow}
@@ -212,10 +215,18 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                       Arată
                     </button>
                   </div>
+                ) : (
+                  <div className="flex gap-2 flex-1 justify-center">
+                    {/* Already answered: show "Arată" to let user flip and review */}
+                    <button
+                      onClick={handleShow}
+                      className="flex items-center gap-2 px-6 py-2 bg-indigo-100 text-indigo-700 rounded-lg font-semibold hover:bg-indigo-200 transition-all active:scale-95"
+                    >
+                      <Eye size={18} />
+                      Arată
+                    </button>
+                  </div>
                 )}
-
-                {/* Spacer when answered */}
-                {hasAnswered && <div className="flex-1"></div>}
 
                 {/* Right side: Skip or Finish button */}
                 {isLastCard && onFinish ? (
@@ -227,7 +238,7 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                     <CheckCircle size={18} />
                     <span className="hidden sm:inline">Finalizare</span>
                   </button>
-                ) : (
+                ) : !hasAnswered ? (
                   <button
                     onClick={onSkip}
                     className="p-2 text-yellow-600 hover:bg-yellow-50 rounded-lg transition-all active:scale-95"
@@ -235,6 +246,8 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                   >
                     <SkipForward size={20} />
                   </button>
+                ) : (
+                  <div className="w-9" /> /* Spacer to maintain layout */
                 )}
               </div>
             </div>
@@ -280,18 +293,14 @@ export const StandardCard: React.FC<StandardCardProps> = ({
               />
             </div>
 
-            {/* Back Content - Randat condiționat pentru a evita "ghosting-ul" de date la tranziție */}
+            {/* Back Content */}
             <div className="text-center px-4">
-              {frontAction !== null && (
-                <>
-                  <div className="text-sm font-semibold text-gray-500 mb-4 uppercase tracking-wide">
-                    Răspuns
-                  </div>
-                  <div className="text-2xl font-bold text-gray-900 animate-fade-in">
-                    {card.back}
-                  </div>
-                </>
-              )}
+              <>
+                <div className="text-sm font-semibold text-gray-500 mb-4 uppercase tracking-wide">
+                  Răspuns
+                </div>
+                <div className="text-2xl font-bold text-gray-900 animate-fade-in">{card.back}</div>
+              </>
             </div>
 
             {/* Sticky Navigation Footer (back) */}
@@ -315,8 +324,8 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                 </button>
 
                 <div className="flex gap-2 flex-1 justify-end">
-                  {/* Flow A: User clicked "Știu" - show "Nu știu" button */}
-                  {frontAction === 'know' && (
+                  {/* Show "Nu știu" when answer is currently correct (allows downgrade) */}
+                  {(frontAction === 'know' || cardAnswer === 'correct') && (
                     <button
                       onClick={handleDontKnow}
                       className="flex items-center gap-2 px-6 py-2 bg-red-100 text-red-700 rounded-lg font-semibold hover:bg-red-200 transition-all active:scale-95"


### PR DESCRIPTION
…ck-nav, empty back

BUG 1: "Nu știu" button was non-functional because handleAnswer skipped answerCard for already-answered cards. Now allows downgrade from correct to incorrect (anti-cheat preserved: upgrade from incorrect to correct still blocked).

BUG 2: "Arată" button was missing when navigating back to a previously answered card. Now shows "Arată" for already-answered cards so user can flip and review the answer.

BUG 3: Back content was empty on back-navigation + flip because it was gated on frontAction !== null (which is null after undo). Removed the conditional — back content always renders.

Also: "Nu știu" now appears on back side whenever current answer is correct (not just when frontAction === 'know'), supporting the review flow after back-navigation. Skip button hidden for already-answered cards.

https://claude.ai/code/session_018A93kX3m5MUXCKFeH75z8o