### PR TITLE
fix(study-session): fix skipped card navigation, completion trigger, …

### DIFF
--- a/src/components/study-session/cards/StandardCard.tsx
+++ b/src/components/study-session/cards/StandardCard.tsx
@@ -25,6 +25,7 @@ interface StandardCardProps {
   isFirstCard?: boolean;
   isLastCard?: boolean;
   hasAnswered?: boolean;
+  isSkipped?: boolean;
   canEditDelete?: boolean;
   onEditCard?: () => void;
   onDeleteCard?: () => void;
@@ -45,6 +46,7 @@ export const StandardCard: React.FC<StandardCardProps> = ({
   isFirstCard = false,
   isLastCard = false,
   hasAnswered = false,
+  isSkipped = false,
   canEditDelete = false,
   onEditCard,
   onDeleteCard,
@@ -198,7 +200,8 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                 </button>
 
                 {/* Action buttons */}
-                {!hasAnswered ? (
+                {!hasAnswered || isSkipped ? (
+                  /* New card or skipped: show both "Știu" and "Arată" */
                   <div className="flex gap-2 flex-1 justify-center">
                     <button
                       onClick={handleKnow}
@@ -216,8 +219,8 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                     </button>
                   </div>
                 ) : (
+                  /* Already answered (correct/incorrect): show only "Arată" for review */
                   <div className="flex gap-2 flex-1 justify-center">
-                    {/* Already answered: show "Arată" to let user flip and review */}
                     <button
                       onClick={handleShow}
                       className="flex items-center gap-2 px-6 py-2 bg-indigo-100 text-indigo-700 rounded-lg font-semibold hover:bg-indigo-200 transition-all active:scale-95"
@@ -238,7 +241,7 @@ export const StandardCard: React.FC<StandardCardProps> = ({
                     <CheckCircle size={18} />
                     <span className="hidden sm:inline">Finalizare</span>
                   </button>
-                ) : !hasAnswered ? (
+                ) : !hasAnswered || isSkipped ? (
                   <button
                     onClick={onSkip}
                     className="p-2 text-yellow-600 hover:bg-yellow-50 rounded-lg transition-all active:scale-95"

--- a/src/components/study-session/modals/SessionCompletionModal.tsx
+++ b/src/components/study-session/modals/SessionCompletionModal.tsx
@@ -1,7 +1,14 @@
 import React from 'react';
-import { Trophy, Save, CheckCircle, RefreshCw } from 'lucide-react';
-import { SessionStatsPieChart } from '../progress/SessionStatsPieChart';
+import { Trophy, Save, CheckCircle, RefreshCw, TrendingUp, AlertTriangle } from 'lucide-react';
+import { Card, AnswerStatus } from '../../../types/models';
 import '../animations/animations.css';
+
+interface TagAccuracy {
+  tag: string;
+  correct: number;
+  total: number;
+  accuracy: number;
+}
 
 interface SessionCompletionModalProps {
   score: number;
@@ -10,14 +17,52 @@ interface SessionCompletionModalProps {
   skippedCount: number;
   totalCards: number;
   xpEarned: number;
+  cards: Card[];
+  answers: Record<string, AnswerStatus>;
   onSaveAndExit: () => void;
   onFinishAndExit: () => void;
   onReviewMistakes?: () => void;
 }
 
+// Map card types to display labels
+const TYPE_LABELS: Record<string, string> = {
+  standard: 'Carduri Standard',
+  quiz: 'Quiz',
+  'multiple-answer': 'Răspuns Multiplu',
+};
+
+// Map card types to colors
+const TYPE_COLORS: Record<string, string> = {
+  standard: 'bg-blue-100 text-blue-700',
+  quiz: 'bg-purple-100 text-purple-700',
+  'multiple-answer': 'bg-teal-100 text-teal-700',
+};
+
+function computeTagAccuracies(cards: Card[], answers: Record<string, AnswerStatus>): TagAccuracy[] {
+  const tagMap = new Map<string, { correct: number; total: number }>();
+
+  for (const card of cards) {
+    const answer = answers[card.id];
+    if (!answer || answer === 'skipped') continue;
+
+    const tag = card.type || 'standard';
+    const entry = tagMap.get(tag) || { correct: 0, total: 0 };
+    entry.total++;
+    if (answer === 'correct') entry.correct++;
+    tagMap.set(tag, entry);
+  }
+
+  return Array.from(tagMap.entries()).map(([tag, { correct, total }]) => ({
+    tag,
+    correct,
+    total,
+    accuracy: total > 0 ? Math.round((correct / total) * 100) : 0,
+  }));
+}
+
 /**
  * SessionCompletionModal - Modal shown when all cards are completed
- * Offers two options: Save progress or Finish session
+ * Shows Strengths vs Growth Areas by card type
  */
 export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
   score,
@@ -26,6 +71,8 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
   skippedCount,
   totalCards,
   xpEarned,
+  cards,
+  answers,
   onSaveAndExit,
   onFinishAndExit,
   onReviewMistakes,
@@ -33,83 +80,101 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
   const isPerfect = score === 100;
   const hasReviewableCards = incorrectCount + skippedCount > 0;
 
+  const tagAccuracies = React.useMemo(() => computeTagAccuracies(cards, answers), [cards, answers]);
+
+  // Strengths: >= 80% accuracy, sorted highest first
+  const strengths = tagAccuracies
+    .filter(t => t.accuracy >= 80)
+    .sort((a, b) => b.accuracy - a.accuracy);
+
+  // Growth areas: < 80% accuracy, sorted lowest first (most urgent)
+  const growthAreas = tagAccuracies
+    .filter(t => t.accuracy < 80)
+    .sort((a, b) => a.accuracy - b.accuracy);
+
   return (
     <div
       className="fixed inset-0 bg-black/50 z-[100] flex items-center justify-center p-4 backdrop-blur-sm animate-fade-in"
       onClick={onSaveAndExit}
     >
       <div
-        className={`rounded-3xl shadow-2xl max-w-md w-full p-8 animate-scale-up ${
+        className={`rounded-3xl shadow-2xl max-w-md w-full p-6 animate-scale-up max-h-[90vh] overflow-y-auto ${
           isPerfect
             ? 'bg-gradient-to-br from-yellow-50 via-amber-50 to-yellow-100 border-2 border-yellow-400'
             : 'bg-white'
         }`}
         onClick={e => e.stopPropagation()}
       >
-        {/* Icon */}
-        <div
-          className={`w-20 h-20 rounded-full flex items-center justify-center mx-auto mb-6 ${
-            isPerfect ? 'bg-gradient-to-br from-yellow-400 to-amber-500 shadow-lg' : 'bg-orange-100'
-          }`}
-        >
-          {isPerfect ? (
-            <Trophy className="w-12 h-12 text-white animate-bounce" />
-          ) : (
-            <CheckCircle className="w-12 h-12 text-orange-600" />
+        {/* XP Earned + Score summary */}
+        <div className="flex items-center justify-between mb-5">
+          <div className="flex items-center gap-3">
+            {isPerfect ? (
+              <div className="w-12 h-12 rounded-full bg-gradient-to-br from-yellow-400 to-amber-500 shadow-lg flex items-center justify-center">
+                <Trophy className="w-7 h-7 text-white" />
+              </div>
+            ) : (
+              <div className="w-12 h-12 rounded-full bg-indigo-100 flex items-center justify-center">
+                <CheckCircle className="w-7 h-7 text-indigo-600" />
+              </div>
+            )}
+            <div>
+              <div className="text-lg font-bold text-gray-900">
+                {correctCount}/{totalCards} corecte
+              </div>
+              <div className="text-sm text-gray-500">Scor: {score}%</div>
+            </div>
+          </div>
+          {xpEarned > 0 && (
+            <div className="text-right">
+              <div className="text-2xl font-black text-yellow-600">+{xpEarned}</div>
+              <div className="text-xs font-semibold text-yellow-700">XP</div>
+            </div>
           )}
         </div>
 
-        {/* Title */}
-        <h2
-          className={`text-2xl font-bold text-center mb-4 ${
-            isPerfect ? 'text-yellow-900' : 'text-gray-900'
-          }`}
-        >
-          {isPerfect ? '🎉 Sesiune Perfectă! 🎉' : 'Final sesiune'}
-        </h2>
-
-        {/* XP Earned - Promoted after title */}
-        {xpEarned > 0 && (
-          <div
-            className={`rounded-xl p-4 mb-6 text-center ${
-              isPerfect
-                ? 'bg-gradient-to-r from-yellow-100 to-amber-100 border-2 border-yellow-300'
-                : 'bg-gradient-to-r from-yellow-50 to-amber-50'
-            }`}
-          >
-            <div
-              className={`text-sm font-semibold mb-1 ${
-                isPerfect ? 'text-yellow-900' : 'text-gray-600'
-              }`}
-            >
-              XP Câștigat
-            </div>
-            <div className="text-3xl font-black text-yellow-600">+{xpEarned} XP</div>
+        {/* Perfect Score Banner */}
+        {isPerfect && (
+          <div className="bg-gradient-to-r from-yellow-100 to-amber-100 border-2 border-yellow-300 rounded-xl p-3 mb-5 text-center">
+            <p className="text-yellow-900 font-bold">Sesiune Perfecta!</p>
           </div>
         )}
 
-        {/* Pie Chart Visualization - Reduced size */}
-        <div className="mb-6 flex justify-center">
-          <SessionStatsPieChart
-            correctCount={correctCount}
-            incorrectCount={incorrectCount}
-            skippedCount={skippedCount}
-            totalCards={totalCards}
-            size="medium"
-            showLegend={true}
-          />
-        </div>
+        {/* Strengths Section */}
+        {strengths.length > 0 && (
+          <div className="mb-4">
+            <div className="flex items-center gap-2 mb-3">
+              <TrendingUp size={18} className="text-green-600" />
+              <h3 className="text-sm font-bold text-green-700 uppercase tracking-wide">
+                Puncte Tari
+              </h3>
+            </div>
+            <div className="space-y-2">
+              {strengths.map(tag => (
+                <TagProgressBar key={tag.tag} tag={tag} variant="strength" />
+              ))}
+            </div>
+          </div>
+        )}
 
-        {/* Perfect Score Message */}
-        {isPerfect && (
-          <div className="bg-gradient-to-r from-yellow-100 to-amber-100 border-2 border-yellow-300 rounded-xl p-4 mb-6 text-center">
-            <p className="text-yellow-900 font-bold text-lg">⭐ Excelent! Scor perfect! ⭐</p>
-            <p className="text-yellow-800 text-sm mt-2">Ai răspuns corect la toate întrebările!</p>
+        {/* Growth Areas Section */}
+        {growthAreas.length > 0 && (
+          <div className="mb-4">
+            <div className="flex items-center gap-2 mb-3">
+              <AlertTriangle size={18} className="text-orange-600" />
+              <h3 className="text-sm font-bold text-orange-700 uppercase tracking-wide">
+                Zone de Crestere
+              </h3>
+            </div>
+            <div className="space-y-2">
+              {growthAreas.map(tag => (
+                <TagProgressBar key={tag.tag} tag={tag} variant="growth" />
+              ))}
+            </div>
           </div>
         )}
 
         {/* Action Buttons */}
-        <div className="space-y-3">
+        <div className="space-y-3 mt-5">
           {/* Review Unknown/Skipped Cards */}
           {hasReviewableCards && onReviewMistakes && (
             <button
@@ -117,7 +182,7 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
               className="w-full bg-amber-500 hover:bg-amber-600 text-white font-bold py-4 rounded-xl transition-all shadow-lg flex items-center justify-center gap-2 active:scale-98"
             >
               <RefreshCw size={20} />
-              Exersează Greșite & Sărite ({incorrectCount + skippedCount})
+              Exerseaza Gresite & Sarite ({incorrectCount + skippedCount})
             </button>
           )}
 
@@ -127,7 +192,7 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
             className="w-full bg-gray-100 hover:bg-gray-200 text-gray-700 font-bold py-4 rounded-xl transition-all shadow-sm flex items-center justify-center gap-2 active:scale-98"
           >
             <Save size={20} />
-            Salvează & Ieși
+            Salveaza & Iesi
           </button>
 
           {/* Finish & Exit (sync to backend) */}
@@ -136,17 +201,54 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
             className="w-full bg-indigo-600 hover:bg-indigo-700 text-white font-bold py-4 rounded-xl transition-all shadow-lg flex items-center justify-center gap-2 active:scale-98"
           >
             <CheckCircle size={20} />
-            Finalizează & Ieși
+            Finalizeaza & Iesi
           </button>
         </div>
 
         {/* Helper Text */}
         <p className="text-xs text-gray-500 text-center mt-4">
-          &ldquo;Salvează & Ieși&rdquo; păstrează progresul pentru mai târziu.
+          &ldquo;Salveaza & Iesi&rdquo; pastreaza progresul pentru mai tarziu.
           <br />
-          &ldquo;Finalizează & Ieși&rdquo; marchează sesiunea ca completă.
+          &ldquo;Finalizeaza & Iesi&rdquo; marcheaza sesiunea ca completa.
         </p>
       </div>
+    </div>
+  );
+};
+
+/** Mini progress bar for a tag's accuracy */
+const TagProgressBar: React.FC<{ tag: TagAccuracy; variant: 'strength' | 'growth' }> = ({
+  tag,
+  variant,
+}) => {
+  const label = TYPE_LABELS[tag.tag] || tag.tag;
+  const colorClass = TYPE_COLORS[tag.tag] || 'bg-gray-100 text-gray-700';
+
+  const barColor =
+    variant === 'strength' ? 'bg-green-500' : tag.accuracy === 0 ? 'bg-red-500' : 'bg-orange-500';
+
+  const priorityLabel = tag.accuracy === 0 ? 'Prioritate critica' : null;
+
+  return (
+    <div className="rounded-xl bg-gray-50 p-3">
+      <div className="flex items-center justify-between mb-2">
+        <span className={`text-xs font-semibold px-2 py-0.5 rounded-md ${colorClass}`}>
+          {label}
+        </span>
+        <span className="text-sm font-bold text-gray-700">
+          {tag.correct}/{tag.total} ({tag.accuracy}%)
+        </span>
+      </div>
+      {/* Progress bar */}
+      <div className="w-full h-2 bg-gray-200 rounded-full overflow-hidden">
+        <div
+          className={`h-full rounded-full transition-all duration-500 ${barColor}`}
+          style={{ width: `${Math.max(tag.accuracy, 2)}%` }}
+        />
+      </div>
+      {priorityLabel && (
+        <div className="text-xs font-semibold text-red-600 mt-1">{priorityLabel}</div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
…and refactor modal

1. StandardCard: distinguish skipped vs answered on back-navigation. Skipped cards show both "Știu" + "Arată" (can be re-answered). Answered cards (correct/incorrect) show only "Arată" for review. New isSkipped prop passed from container.

2. Completion trigger: prevent modal from firing on session resume when all cards already have answers (including skips). Uses a ref to track previous answer count — modal only triggers when user actively answers a new card (count increases).

3. SessionCompletionModal: replace pie chart + icon with semantic Strengths vs Growth Areas layout. Groups results by card type (standard/quiz/multiple-answer) with mini progress bars. Color-coded tags, accuracy percentages, "Prioritate critică" label for 0% accuracy. Compact header with score + XP inline.

https://claude.ai/code/session_018A93kX3m5MUXCKFeH75z8o