### PR TITLE
fix(study-session): fix premature completion modal and limit tag display

### DIFF
--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -109,34 +109,6 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
     };
   }, [sessionId, loadSession, enableAutoSave, disableAutoSave, resetSessionState]);
 
-  // Track previous answer count to detect when user actively answers (not on resume)
-  const prevAnswerCountRef = useRef<number>(Object.keys(answers).length);
-
-  // Check if session is complete (all cards answered)
-  useEffect(() => {
-    if (!currentSession?.cards) return;
-
-    const totalCards = currentSession.cards.length;
-    const answeredCards = Object.keys(answers).length;
-    const prevCount = prevAnswerCountRef.current;
-    prevAnswerCountRef.current = answeredCards;
-
-    // Only trigger when user ACTIVELY answered a new card (count increased)
-    // This prevents the modal from firing on resume when skipped cards already fill all slots
-    const userJustAnswered = answeredCards > prevCount;
-
-    if (
-      answeredCards === totalCards &&
-      totalCards > 0 &&
-      !showCompletionModal &&
-      userJustAnswered
-    ) {
-      setTimeout(() => {
-        setShowCompletionModal(true);
-      }, 6000); // 6 seconds delay to let user read feedback and explanation on last card
-    }
-  }, [answers, currentSession, showCompletionModal]);
-
   // Handle back navigation - sync progress before leaving
   const handleBack = async () => {
     await syncProgress();
@@ -544,8 +516,9 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
               onNext={() => {
                 if (currentCardIndex < (currentSession?.cards?.length || 0) - 1) {
                   nextCard();
+                } else {
+                  setShowCompletionModal(true);
                 }
-                // Don't manually trigger modal - useEffect handles it
               }}
               onSkip={() => {
                 skipCard(currentCard.id);
@@ -566,18 +539,19 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
               card={currentCard}
               onAnswer={handleAnswer}
               onAutoAdvance={() => {
-                // Auto-advance to next card if not on last card
                 const totalCards = currentSession?.cards?.length || 0;
                 if (currentCardIndex < totalCards - 1) {
                   nextCard();
+                } else {
+                  setShowCompletionModal(true);
                 }
-                // Don't manually trigger modal - useEffect handles it
               }}
               onNext={() => {
                 if (currentCardIndex < (currentSession?.cards?.length || 0) - 1) {
                   nextCard();
+                } else {
+                  setShowCompletionModal(true);
                 }
-                // Don't manually trigger modal - useEffect handles it
               }}
               onSkip={() => {
                 skipCard(currentCard.id);
@@ -597,12 +571,12 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
               card={currentCard}
               onAnswer={handleAnswer}
               onAutoAdvance={() => {
-                // Auto-advance to next card if not on last card
                 const totalCards = currentSession?.cards?.length || 0;
                 if (currentCardIndex < totalCards - 1) {
                   nextCard();
+                } else {
+                  setShowCompletionModal(true);
                 }
-                // Don't manually trigger modal - useEffect handles it
               }}
               onNext={nextCard}
               onSkip={() => {
@@ -623,18 +597,19 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
               card={currentCard}
               onAnswer={handleAnswer}
               onAutoAdvance={() => {
-                // Auto-advance to next card if not on last card
                 const totalCards = currentSession?.cards?.length || 0;
                 if (currentCardIndex < totalCards - 1) {
                   nextCard();
+                } else {
+                  setShowCompletionModal(true);
                 }
-                // Don't manually trigger modal - useEffect handles it
               }}
               onNext={() => {
                 if (currentCardIndex < (currentSession?.cards?.length || 0) - 1) {
                   nextCard();
+                } else {
+                  setShowCompletionModal(true);
                 }
-                // Don't manually trigger modal - useEffect handles it
               }}
               onSkip={() => {
                 skipCard(currentCard.id);

--- a/src/components/study-session/modals/SessionCompletionModal.tsx
+++ b/src/components/study-session/modals/SessionCompletionModal.tsx
@@ -81,7 +81,10 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
   const isPerfect = score === 100;
   const hasReviewableCards = incorrectCount + skippedCount > 0;
 
-  const tagAccuracies = React.useMemo(() => computeTagAccuracies(cards, answers), [cards, answers]);
+  const tagAccuracies = React.useMemo(
+    () => computeTagAccuracies(cards, answers).filter(t => t.total > 1),
+    [cards, answers]
+  );
 
   // Build a stable color index map: each unique tag gets a consistent color
   const tagColorMap = React.useMemo(() => {
@@ -90,15 +93,17 @@ export const SessionCompletionModal: React.FC<SessionCompletionModalProps> = ({
     return map;
   }, [tagAccuracies]);
 
-  // Strengths: >= 80% accuracy, sorted highest first
+  // Strengths: >= 80% accuracy, sorted highest first, top 3
   const strengths = tagAccuracies
     .filter(t => t.accuracy >= 80)
-    .sort((a, b) => b.accuracy - a.accuracy);
+    .sort((a, b) => b.accuracy - a.accuracy)
+    .slice(0, 3);
 
-  // Growth areas: < 80% accuracy, sorted lowest first (most urgent)
+  // Growth areas: < 80% accuracy, sorted lowest first (most urgent), top 3
   const growthAreas = tagAccuracies
     .filter(t => t.accuracy < 80)
-    .sort((a, b) => a.accuracy - b.accuracy);
+    .sort((a, b) => a.accuracy - b.accuracy)
+    .slice(0, 3);
 
   return (
     <div


### PR DESCRIPTION
BUG FIX - Completion modal appeared prematurely on session resume:
- Root cause: useEffect auto-trigger with prevAnswerCountRef was fooled when loadSession populated answers (count jumped 0→N, triggering modal)
- Fix: Remove the buggy useEffect entirely. Modal now triggers only via:
  1. onAutoAdvance/onNext on the last card (quiz/type-answer/multiple-answer)
  2. onFinish button shown on last card (all card types)
  3. Manual "Finalizare" header button

IMPROVEMENT - Tag statistics in completion modal:
- Filter out tags that have only 1 card (not meaningful for accuracy)
- Limit display to top 3 Strengths and top 3 Growth Areas

https://claude.ai/code/session_018A93kX3m5MUXCKFeH75z8o