### PR TITLE
fix(achievements): fix badge logic, centering, and refresh persistence

### DIFF
--- a/server/routes/achievements.ts
+++ b/server/routes/achievements.ts
@@ -162,6 +162,10 @@ export async function checkAndUnlockAchievements(
           if (!sessionContext) break;
           const durationMinutes = sessionContext.durationSeconds / 60;
           if (durationMinutes <= 0) break;
+          // Require at least 10 correct answers AND the rate to exceed the threshold
+          // This prevents triggering after just 1 fast card
+          const minCorrectRequired = Math.max(10, achievement.condition_value);
+          if (sessionContext.correctCount < minCorrectRequired) break;
           const cardsPerMinute = sessionContext.correctCount / durationMinutes;
           unlockConditionMet = cardsPerMinute >= achievement.condition_value;
           break;

--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -80,7 +80,7 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
     null
   );
   const [allAchievements, setAllAchievements] = useState<ApiAchievement[]>([]);
-  const { checkAchievements } = useAchievementChecker(allAchievements);
+  const { checkAchievements, recordCorrectAnswer } = useAchievementChecker(allAchievements);
 
   // Refs for synchronous level-up XP tracking (React state via updateUser is async)
   // userXPStateRef: holds the post-level-up user state so checkLevelUp reads fresh values
@@ -359,6 +359,11 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
         // Check for level up during session
         checkLevelUp();
       }, 10);
+
+      // Record correct answer timestamp for sliding-window achievement checks
+      if (isCorrect) {
+        recordCorrectAnswer();
+      }
 
       // Check for streak celebration (5, 10, 15, 20, etc.) - only if correct
       if (isCorrect) {

--- a/src/components/study-session/animations/AchievementCelebration.tsx
+++ b/src/components/study-session/animations/AchievementCelebration.tsx
@@ -102,7 +102,7 @@ export const AchievementCelebration: React.FC<AchievementCelebrationProps> = ({
   }, []);
 
   const overlay = (
-    <div className="fixed inset-0 z-[9998] flex flex-col items-center justify-center pointer-events-none">
+    <div className="fixed inset-0 z-[9999] flex flex-col items-center justify-center bg-black/60 backdrop-blur-sm pointer-events-none">
       {/* Confetti particles */}
       {particles.map(p => (
         <div
@@ -125,16 +125,19 @@ export const AchievementCelebration: React.FC<AchievementCelebrationProps> = ({
       ))}
 
       {/* Badge content */}
-      <div className="animate-pop-in flex flex-col items-center gap-3 bg-white/95 backdrop-blur-md p-8 rounded-3xl shadow-2xl border-4 border-amber-400">
-        <div className="text-sm font-bold uppercase tracking-widest text-amber-600">
-          Badge Unlocked!
+      <div className="animate-level-up flex flex-col items-center gap-4">
+        <div className="text-5xl">🏆</div>
+        <div className="flex flex-col items-center gap-3 bg-white/95 backdrop-blur-md p-8 rounded-3xl shadow-2xl border-4 border-amber-400">
+          <div className="text-sm font-bold uppercase tracking-widest text-amber-600">
+            Badge Unlocked!
+          </div>
+          <div
+            className={`w-20 h-20 rounded-full flex items-center justify-center ${color || 'bg-amber-100 text-amber-600'}`}
+          >
+            <Icon size={40} />
+          </div>
+          <h2 className="text-2xl font-black text-gray-900 text-center">{title}</h2>
         </div>
-        <div
-          className={`w-20 h-20 rounded-full flex items-center justify-center ${color || 'bg-amber-100 text-amber-600'}`}
-        >
-          <Icon size={40} />
-        </div>
-        <h2 className="text-2xl font-black text-gray-900 text-center">{title}</h2>
       </div>
     </div>
   );


### PR DESCRIPTION
- Lightning Fast: require sliding window of N cards within 60s instead of naive rate calculation that triggered after 1 card. Server-side also requires minimum 10 correct answers.
- Badge celebration: match LevelUpOverlay centering with fixed inset-0, bg-black/60 backdrop-blur-sm, z-[9999], and animate-level-up.
- Refresh persistence: store triggered achievement IDs in sessionStorage so page refresh doesn't re-trigger badge animations. Cleared on session reset.

https://claude.ai/code/session_01JkVHfxCcHAqAPAv94JgXcB