### PR TITLE
feat(cards): teacher authority edit & advanced card editor

### DIFF
--- a/public/locales/en/decks.json
+++ b/public/locales/en/decks.json
@@ -106,7 +106,18 @@
     "tagsPlaceholder": "Type a tag and press Enter...",
     "bulkEdit": "Bulk Edit",
     "bulkTagsLabel": "Assign tags to {{count}} selected cards",
-    "applyTags": "Apply Tags"
+    "applyTags": "Apply Tags",
+    "searchPlaceholder": "Search cards...",
+    "filterByType": "All Types",
+    "selectAll": "Select All",
+    "deselectAll": "Deselect All",
+    "bulkChangeType": "Change Type",
+    "bulkTypeLabel": "Change type for {{count}} selected cards",
+    "applyType": "Apply Type",
+    "typeStandard": "Standard",
+    "typeQuiz": "Quiz",
+    "typeAnswer": "Type Answer",
+    "typeMultipleAnswer": "Multiple Answer"
   },
   "loading": {
     "message": "Generating cards..."
@@ -140,7 +151,9 @@
     "cardsAdded": "Added {{count}} cards successfully",
     "openEditCards": "Opening card editor...",
     "bulkTagsApplied": "Tags applied to {{count}} cards",
-    "bulkTagsError": "Error applying tags"
+    "bulkTagsError": "Error applying tags",
+    "bulkTypeApplied": "Type changed for {{count}} cards",
+    "bulkTypeError": "Error changing card type"
   },
   "guestPrompt": {
     "createDeck": {

--- a/public/locales/en/globalDecks.json
+++ b/public/locales/en/globalDecks.json
@@ -33,7 +33,8 @@
   },
   "menu": {
     "leaveReview": "Leave a review",
-    "report": "Report deck"
+    "report": "Report deck",
+    "editCards": "Edit cards"
   },
   "toast": {
     "deckCopied": "Deck \"{{title}}\" has been copied to your collection!",

--- a/public/locales/it/decks.json
+++ b/public/locales/it/decks.json
@@ -101,7 +101,23 @@
     "addNewCard": "Aggiungi Nuova Carta",
     "question": "Domanda:",
     "answer": "Risposta:",
-    "contextLabel": "Contesto:"
+    "contextLabel": "Contesto:",
+    "tags": "Tag",
+    "tagsPlaceholder": "Scrivi un tag e premi Invio...",
+    "bulkEdit": "Modifica in blocco",
+    "bulkTagsLabel": "Assegna tag a {{count}} carte selezionate",
+    "applyTags": "Applica Tag",
+    "searchPlaceholder": "Cerca carte...",
+    "filterByType": "Tutti i Tipi",
+    "selectAll": "Seleziona Tutto",
+    "deselectAll": "Deseleziona Tutto",
+    "bulkChangeType": "Cambia Tipo",
+    "bulkTypeLabel": "Cambia tipo per {{count}} carte selezionate",
+    "applyType": "Applica Tipo",
+    "typeStandard": "Standard",
+    "typeQuiz": "Quiz",
+    "typeAnswer": "Risposta Scritta",
+    "typeMultipleAnswer": "Risposta Multipla"
   },
   "loading": {
     "message": "Generazione carte in corso..."
@@ -133,7 +149,11 @@
     "importError": "Errore nell'importazione delle carte",
     "fileReadError": "Errore nella lettura del file",
     "cardsAdded": "{{count}} carte aggiunte con successo",
-    "openEditCards": "Apertura editor carte..."
+    "openEditCards": "Apertura editor carte...",
+    "bulkTagsApplied": "Tag applicati a {{count}} carte",
+    "bulkTagsError": "Errore nell'applicazione dei tag",
+    "bulkTypeApplied": "Tipo cambiato per {{count}} carte",
+    "bulkTypeError": "Errore nel cambio tipo carta"
   },
   "guestPrompt": {
     "createDeck": {

--- a/public/locales/it/globalDecks.json
+++ b/public/locales/it/globalDecks.json
@@ -33,7 +33,8 @@
   },
   "menu": {
     "leaveReview": "Lascia una recensione",
-    "report": "Segnala mazzo"
+    "report": "Segnala mazzo",
+    "editCards": "Modifica carte"
   },
   "toast": {
     "deckCopied": "Il mazzo \"{{title}}\" è stato copiato nella tua collezione!",

--- a/public/locales/ro/decks.json
+++ b/public/locales/ro/decks.json
@@ -108,7 +108,18 @@
     "tagsPlaceholder": "Scrie o etichetă și apasă Enter...",
     "bulkEdit": "Editare în masă",
     "bulkTagsLabel": "Atribuie etichete la {{count}} carduri selectate",
-    "applyTags": "Aplică Etichete"
+    "applyTags": "Aplică Etichete",
+    "searchPlaceholder": "Caută carduri...",
+    "filterByType": "Toate Tipurile",
+    "selectAll": "Selectează Tot",
+    "deselectAll": "Deselectează Tot",
+    "bulkChangeType": "Schimbă Tipul",
+    "bulkTypeLabel": "Schimbă tipul pentru {{count}} carduri selectate",
+    "applyType": "Aplică Tipul",
+    "typeStandard": "Standard",
+    "typeQuiz": "Quiz",
+    "typeAnswer": "Răspuns Scris",
+    "typeMultipleAnswer": "Răspuns Multiplu"
   },
   "loading": {
     "message": "Se generează carduri...",
@@ -151,7 +162,9 @@
     "cardsAdded": "{{count}} carduri adăugate cu succes",
     "openEditCards": "Se deschide editorul de carduri...",
     "bulkTagsApplied": "Etichete aplicate la {{count}} carduri",
-    "bulkTagsError": "Eroare la aplicarea etichetelor"
+    "bulkTagsError": "Eroare la aplicarea etichetelor",
+    "bulkTypeApplied": "Tipul schimbat pentru {{count}} carduri",
+    "bulkTypeError": "Eroare la schimbarea tipului de card"
   },
   "guestPrompt": {
     "createDeck": {

--- a/public/locales/ro/globalDecks.json
+++ b/public/locales/ro/globalDecks.json
@@ -33,7 +33,8 @@
   },
   "menu": {
     "leaveReview": "Lasă o recenzie",
-    "report": "Raportează deck"
+    "report": "Raportează deck",
+    "editCards": "Editează carduri"
   },
   "toast": {
     "deckCopied": "Deck-ul \"{{title}}\" a fost copiat în colecția ta!",


### PR DESCRIPTION
- Grant teachers/admins "Edit cards" access on all public decks in GlobalDecks
- Add card type badge (Standard/Quiz/Type Answer/Multiple Answer) to card preview
- Add search input and card type dropdown filter to EditCardsModal
- Add select-all checkbox that targets visible (filtered) cards
- Add bulk card type change dropdown alongside existing bulk tag editor
- Fetch database-wide tag suggestions (getCardTags without deckId) for bulk mode
- Add translation keys for all new features in en, ro, it

https://claude.ai/code/session_01BiXDGFM22r7S5SNydPcEeN