### PR TITLE
feat(cards): unify card editor & fix bulk tag suggestions

### DIFF
--- a/public/locales/en/decks.json
+++ b/public/locales/en/decks.json
@@ -119,6 +119,32 @@
     "typeAnswer": "Type Answer",
     "typeMultipleAnswer": "Multiple Answer"
   },
+  "editCardModal": {
+    "title": "Edit Card",
+    "cardType": "Card Type",
+    "typeStandard": "Standard (Flip)",
+    "typeQuiz": "Quiz (Single Choice)",
+    "typeMultipleAnswer": "Multiple Answer",
+    "typeAnswer": "Type Answer",
+    "front": "Question (Front)",
+    "back": "Answer (Back)",
+    "context": "Context / Hint (Optional)",
+    "contextPlaceholder": "Additional explanation...",
+    "optionsLabel": "Options",
+    "optionsSingle": "(one correct answer)",
+    "optionsMultiple": "(multiple correct answers)",
+    "optionPlaceholder": "Option {{number}}",
+    "addOption": "Add option",
+    "tags": "Tags",
+    "save": "Save",
+    "saving": "Saving...",
+    "cancel": "Cancel",
+    "errorRequired": "Question and answer are required.",
+    "errorMinOptions": "At least 2 options are required.",
+    "errorNoCorrect": "Select at least one correct answer.",
+    "errorSave": "Error saving the card.",
+    "errorPermission": "Error saving the card. Check permissions."
+  },
   "loading": {
     "message": "Generating cards..."
   },

--- a/public/locales/it/decks.json
+++ b/public/locales/it/decks.json
@@ -119,6 +119,32 @@
     "typeAnswer": "Risposta Scritta",
     "typeMultipleAnswer": "Risposta Multipla"
   },
+  "editCardModal": {
+    "title": "Modifica Carta",
+    "cardType": "Tipo carta",
+    "typeStandard": "Standard (Flip)",
+    "typeQuiz": "Quiz (Scelta singola)",
+    "typeMultipleAnswer": "Risposta multipla",
+    "typeAnswer": "Scrivi la risposta",
+    "front": "Domanda (Fronte)",
+    "back": "Risposta (Retro)",
+    "context": "Contesto / Suggerimento (opzionale)",
+    "contextPlaceholder": "Spiegazione aggiuntiva...",
+    "optionsLabel": "Opzioni",
+    "optionsSingle": "(una sola risposta corretta)",
+    "optionsMultiple": "(più risposte corrette)",
+    "optionPlaceholder": "Opzione {{number}}",
+    "addOption": "Aggiungi opzione",
+    "tags": "Tag",
+    "save": "Salva",
+    "saving": "Salvataggio...",
+    "cancel": "Annulla",
+    "errorRequired": "Domanda e risposta sono obbligatorie.",
+    "errorMinOptions": "Sono necessarie almeno 2 opzioni.",
+    "errorNoCorrect": "Seleziona almeno una risposta corretta.",
+    "errorSave": "Errore nel salvataggio della carta.",
+    "errorPermission": "Errore nel salvataggio della carta. Controlla i permessi."
+  },
   "loading": {
     "message": "Generazione carte in corso..."
   },

--- a/public/locales/ro/decks.json
+++ b/public/locales/ro/decks.json
@@ -121,6 +121,32 @@
     "typeAnswer": "Răspuns Scris",
     "typeMultipleAnswer": "Răspuns Multiplu"
   },
+  "editCardModal": {
+    "title": "Editează Card",
+    "cardType": "Tip card",
+    "typeStandard": "Standard (Flip)",
+    "typeQuiz": "Quiz (Alegere unică)",
+    "typeMultipleAnswer": "Răspuns multiplu",
+    "typeAnswer": "Scrie răspunsul",
+    "front": "Întrebare (Front)",
+    "back": "Răspuns (Back)",
+    "context": "Context / Indiciu (opțional)",
+    "contextPlaceholder": "Explicație suplimentară...",
+    "optionsLabel": "Opțiuni",
+    "optionsSingle": "(o singură variantă corectă)",
+    "optionsMultiple": "(mai multe variante corecte)",
+    "optionPlaceholder": "Opțiunea {{number}}",
+    "addOption": "Adaugă opțiune",
+    "tags": "Etichete",
+    "save": "Salvează",
+    "saving": "Se salvează...",
+    "cancel": "Anulează",
+    "errorRequired": "Întrebarea și răspunsul sunt obligatorii.",
+    "errorMinOptions": "Minim 2 opțiuni sunt necesare.",
+    "errorNoCorrect": "Selectează cel puțin un răspuns corect.",
+    "errorSave": "Eroare la salvarea cardului.",
+    "errorPermission": "Eroare la salvarea cardului. Verifică permisiunile."
+  },
   "loading": {
     "message": "Se generează carduri...",
     "dealerMessages": [


### PR DESCRIPTION
- Replace inline edit in EditCardsModal with the session EditCardModal for a consistent, high-quality editing experience across all entry points (MyDecks, GlobalDecks, Study Sessions)
- Add i18n support to EditCardModal (en, ro, it) replacing hardcoded strings
- Replace manual tag input in EditCardModal with TagInput component for autocomplete with debounced database-wide suggestions
- Add existingTags prop to EditCardModal for tag autocomplete
- Fix bulk tag suggestions by combining API tags + local deck card tags, ensuring suggestions work even when editing non-owned decks
- Simplify EditCardsModal by removing ~300 lines of inline edit state/UI

https://claude.ai/code/session_01BiXDGFM22r7S5SNydPcEeN