### PR TITLE
feat(global-decks): smart grid layout, rating filter, and admin menu …

### DIFF
--- a/public/locales/en/globalDecks.json
+++ b/public/locales/en/globalDecks.json
@@ -12,6 +12,9 @@
     "placeholder": "Search by title, topic, or creator...",
     "allSubjects": "All Subjects",
     "allLevels": "All Levels",
+    "allRatings": "All Ratings",
+    "stars": "{{count}} Stars",
+    "starsAndAbove": "{{count}}+ Stars",
     "level": "Level {{level}}",
     "showing": "Showing {{filtered}} of {{total}} decks",
     "resetFilters": "Reset filters"
@@ -34,13 +37,20 @@
   "menu": {
     "leaveReview": "Leave a review",
     "report": "Report deck",
-    "editCards": "Edit cards"
+    "editCards": "Edit cards",
+    "editDeck": "Edit deck",
+    "deleteDeck": "Delete deck",
+    "deleteConfirm": "Are you sure you want to delete \"{{title}}\"? This action cannot be undone.",
+    "makePrivate": "Make private",
+    "makePublic": "Make public"
   },
   "toast": {
     "deckCopied": "Deck \"{{title}}\" has been copied to your collection!",
     "copyNotAvailable": "Copy function is not currently available",
     "loadError": "Could not load public decks",
-    "generalError": "Error loading decks"
+    "generalError": "Error loading decks",
+    "deckDeleted": "Deck \"{{title}}\" has been deleted",
+    "visibilityChanged": "Deck visibility has been updated"
   },
   "loading": "Loading global decks..."
 }

--- a/public/locales/it/globalDecks.json
+++ b/public/locales/it/globalDecks.json
@@ -12,6 +12,9 @@
     "placeholder": "Cerca per titolo, argomento o creatore...",
     "allSubjects": "Tutte le Materie",
     "allLevels": "Tutti i Livelli",
+    "allRatings": "Tutte le Valutazioni",
+    "stars": "{{count}} Stelle",
+    "starsAndAbove": "{{count}}+ Stelle",
     "level": "Livello {{level}}",
     "showing": "Mostrando {{filtered}} di {{total}} mazzi",
     "resetFilters": "Ripristina filtri"
@@ -34,13 +37,20 @@
   "menu": {
     "leaveReview": "Lascia una recensione",
     "report": "Segnala mazzo",
-    "editCards": "Modifica carte"
+    "editCards": "Modifica carte",
+    "editDeck": "Modifica mazzo",
+    "deleteDeck": "Elimina mazzo",
+    "deleteConfirm": "Sei sicuro di voler eliminare \"{{title}}\"? Questa azione non può essere annullata.",
+    "makePrivate": "Rendi privato",
+    "makePublic": "Rendi pubblico"
   },
   "toast": {
     "deckCopied": "Il mazzo \"{{title}}\" è stato copiato nella tua collezione!",
     "copyNotAvailable": "La funzione di copia non è al momento disponibile",
     "loadError": "Impossibile caricare i mazzi pubblici",
-    "generalError": "Errore nel caricamento dei mazzi"
+    "generalError": "Errore nel caricamento dei mazzi",
+    "deckDeleted": "Il mazzo \"{{title}}\" è stato eliminato",
+    "visibilityChanged": "La visibilità del mazzo è stata aggiornata"
   },
   "loading": "Caricamento mazzi globali..."
 }

--- a/public/locales/ro/globalDecks.json
+++ b/public/locales/ro/globalDecks.json
@@ -12,6 +12,9 @@
     "placeholder": "Caută după titlu, topic sau creator...",
     "allSubjects": "Toate Disciplinele",
     "allLevels": "Toate Nivelurile",
+    "allRatings": "Toate Ratingurile",
+    "stars": "{{count}} Stele",
+    "starsAndAbove": "{{count}}+ Stele",
     "level": "Nivel {{level}}",
     "showing": "Afișare {{filtered}} din {{total}} deck-uri",
     "resetFilters": "Resetează filtrele"
@@ -34,13 +37,20 @@
   "menu": {
     "leaveReview": "Lasă o recenzie",
     "report": "Raportează deck",
-    "editCards": "Editează carduri"
+    "editCards": "Editează carduri",
+    "editDeck": "Editează deck",
+    "deleteDeck": "Șterge deck",
+    "deleteConfirm": "Ești sigur că vrei să ștergi \"{{title}}\"? Această acțiune nu poate fi anulată.",
+    "makePrivate": "Fă privat",
+    "makePublic": "Fă public"
   },
   "toast": {
     "deckCopied": "Deck-ul \"{{title}}\" a fost copiat în colecția ta!",
     "copyNotAvailable": "Funcția de copiere nu este disponibilă momentan",
     "loadError": "Nu s-au putut încărca deck-urile publice",
-    "generalError": "Eroare la încărcarea deck-urilor"
+    "generalError": "Eroare la încărcarea deck-urilor",
+    "deckDeleted": "Deck-ul \"{{title}}\" a fost șters",
+    "visibilityChanged": "Vizibilitatea deck-ului a fost actualizată"
   },
   "loading": "Se încarcă deck-urile globale..."
 }

--- a/server/routes/decks.ts
+++ b/server/routes/decks.ts
@@ -21,6 +21,7 @@ router.get('/', optionalAuth, async (req: Request, res: Response) => {
       publicOnly = 'false',
       sortBy = 'createdAt',
       sortOrder = 'desc',
+      minRating,
     } = req.query;
 
     const pageNum = Math.max(1, parseInt(page as string));
@@ -81,12 +82,21 @@ router.get('/', optionalAuth, async (req: Request, res: Response) => {
       params.push(`%${search}%`, `%${search}%`);
     }
 
+    if (minRating) {
+      const rating = parseFloat(minRating as string);
+      if (!isNaN(rating) && rating > 0) {
+        whereClause += ` AND d.average_rating >= $${paramIndex++}`;
+        params.push(rating);
+      }
+    }
+
     // Sort mapping
     const sortMap: Record<string, string> = {
       title: 'd.title',
       createdAt: 'd.created_at',
       lastStudied: 'd.last_studied',
       totalCards: 'd.total_cards',
+      rating: 'd.average_rating',
     };
     const sortColumn = sortMap[sortBy as string] || 'd.created_at';
     const order = sortOrder === 'asc' ? 'ASC' : 'DESC';

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -128,8 +128,9 @@ export interface DeckListParams {
   search?: string;
   ownedOnly?: boolean;
   publicOnly?: boolean;
-  sortBy?: 'title' | 'createdAt' | 'lastStudied' | 'totalCards';
+  sortBy?: 'title' | 'createdAt' | 'lastStudied' | 'totalCards' | 'rating';
   sortOrder?: 'asc' | 'desc';
+  minRating?: number;
 }
 
 // ============================================


### PR DESCRIPTION
…options

- Smart grid: categories with 1-2 decks use fewer columns (max-w constrained)
- Rating filter: new dropdown with 5/4+/3+/2+ stars options (client + backend)
- Backend: add minRating WHERE clause and rating to sortMap
- Admin menu: add delete deck, toggle visibility (make private/public)
- Owner menu: add delete option for own decks
- i18n: add new translation keys for all 3 languages (EN/RO/IT)

https://claude.ai/code/session_01R1FuBQD4VqMxrNFD4bALQF