### PR TITLE
feat(settings): add gamification features and fix achievement persist…

### DIFF
--- a/public/locales/en/dashboard.json
+++ b/public/locales/en/dashboard.json
@@ -27,7 +27,8 @@
     "decksCreated": "Decks created",
     "cardsInStudy": "Cards in study",
     "minutes": "min.",
-    "hours": "{{hours}}h"
+    "hours": "{{hours}}h",
+    "shieldActive": "Protected"
   },
   "dailyChallenges": {
     "title": "Daily Challenges",
@@ -44,6 +45,9 @@
     "streak": {
       "title": "Maintain streak",
       "description": "Study for at least 10 minutes OR answer correctly 20 cards today to keep your streak!"
+    },
+    "dailyXP": {
+      "title": "Earn {{count}} XP today"
     }
   },
   "activityCalendar": {

--- a/public/locales/en/settings.json
+++ b/public/locales/en/settings.json
@@ -26,10 +26,16 @@
     "title": "Learning preferences",
     "language": "App language",
     "languageDesc": "Choose the language you want to see the app in",
-    "focusMode": "Focus mode",
-    "focusModeDesc": "Hide notifications during study",
-    "shuffleCards": "Shuffle cards",
-    "shuffleCardsDesc": "Present cards in random order",
+    "dailyXPGoal": "Daily XP Goal",
+    "dailyXPGoalDesc": "Set your minimum daily XP target",
+    "dailyXPGoalValue": "{{count}} XP",
+    "streakShield": "Streak Shield",
+    "streakShieldDesc": "Protects your streak if you miss one day of study",
+    "streakShieldActive": "Shield Active",
+    "streakShieldActivate": "Activate Shield",
+    "streakShieldCost": "Cost: 500 XP",
+    "streakShieldNotEnoughXP": "Not enough XP (need 500)",
+    "streakShieldConfirm": "Spend 500 XP to activate Streak Shield?",
     "newCardsPerDay": "New cards per day",
     "cardsCount": "{{count}} cards"
   },
@@ -40,7 +46,10 @@
   },
   "actions": {
     "saveChanges": "Save changes",
-    "cancel": "Cancel"
+    "cancel": "Cancel",
+    "saveSuccess": "Changes saved successfully",
+    "saveError": "Failed to save",
+    "saveErrorDesc": "Please try again"
   },
   "appearance": {
     "title": "Appearance",

--- a/public/locales/it/dashboard.json
+++ b/public/locales/it/dashboard.json
@@ -27,7 +27,8 @@
     "decksCreated": "Mazzi creati",
     "cardsInStudy": "Carte in studio",
     "minutes": "min.",
-    "hours": "{{hours}}h"
+    "hours": "{{hours}}h",
+    "shieldActive": "Protetto"
   },
   "dailyChallenges": {
     "title": "Sfide Giornaliere",
@@ -44,6 +45,9 @@
     "streak": {
       "title": "Mantieni la serie",
       "description": "Studia per almeno 10 minuti O rispondi correttamente a 20 carte oggi per mantenere la tua serie!"
+    },
+    "dailyXP": {
+      "title": "Guadagna {{count}} XP oggi"
     }
   },
   "activityCalendar": {

--- a/public/locales/it/settings.json
+++ b/public/locales/it/settings.json
@@ -26,10 +26,16 @@
     "title": "Preferenze di apprendimento",
     "language": "Lingua dell'app",
     "languageDesc": "Scegli la lingua in cui vuoi vedere l'app",
-    "focusMode": "Modalità concentrazione",
-    "focusModeDesc": "Nascondi le notifiche durante lo studio",
-    "shuffleCards": "Mescola le carte",
-    "shuffleCardsDesc": "Presenta le carte in ordine casuale",
+    "dailyXPGoal": "Obiettivo XP Giornaliero",
+    "dailyXPGoalDesc": "Imposta il tuo obiettivo minimo di XP giornaliero",
+    "dailyXPGoalValue": "{{count}} XP",
+    "streakShield": "Scudo Serie",
+    "streakShieldDesc": "Protegge la tua serie se salti un giorno di studio",
+    "streakShieldActive": "Scudo Attivo",
+    "streakShieldActivate": "Attiva Scudo",
+    "streakShieldCost": "Costo: 500 XP",
+    "streakShieldNotEnoughXP": "XP insufficiente (servono 500)",
+    "streakShieldConfirm": "Spendere 500 XP per attivare lo Scudo Serie?",
     "newCardsPerDay": "Nuove carte al giorno",
     "cardsCount": "{{count}} carte"
   },
@@ -40,7 +46,10 @@
   },
   "actions": {
     "saveChanges": "Salva modifiche",
-    "cancel": "Annulla"
+    "cancel": "Annulla",
+    "saveSuccess": "Modifiche salvate con successo",
+    "saveError": "Errore nel salvataggio",
+    "saveErrorDesc": "Per favore riprova"
   },
   "appearance": {
     "title": "Aspetto",

--- a/public/locales/ro/dashboard.json
+++ b/public/locales/ro/dashboard.json
@@ -27,7 +27,8 @@
     "decksCreated": "Deck-uri create",
     "cardsInStudy": "Carduri în studiu",
     "minutes": "min.",
-    "hours": "{{hours}}h"
+    "hours": "{{hours}}h",
+    "shieldActive": "Protejat"
   },
   "dailyChallenges": {
     "title": "Provocări Zilnice",
@@ -44,6 +45,9 @@
     "streak": {
       "title": "Menține streak-ul",
       "description": "Studiază cel puțin 10 minute SAU răspunde corect la 20 de carduri astăzi pentru a-ți menține seria!"
+    },
+    "dailyXP": {
+      "title": "Câștigă {{count}} XP azi"
     }
   },
   "activityCalendar": {

--- a/public/locales/ro/settings.json
+++ b/public/locales/ro/settings.json
@@ -26,10 +26,16 @@
     "title": "Preferințe de învățare",
     "language": "Limba aplicației",
     "languageDesc": "Alege limba în care vrei să vezi aplicația",
-    "focusMode": "Mod concentrare",
-    "focusModeDesc": "Ascunde notificările în timpul studiului",
-    "shuffleCards": "Amestecă cardurile",
-    "shuffleCardsDesc": "Prezintă cardurile în ordine aleatorie",
+    "dailyXPGoal": "Obiectiv XP Zilnic",
+    "dailyXPGoalDesc": "Setează obiectivul minim zilnic de XP",
+    "dailyXPGoalValue": "{{count}} XP",
+    "streakShield": "Scut Serie",
+    "streakShieldDesc": "Protejează seria ta dacă ratezi o zi de studiu",
+    "streakShieldActive": "Scut Activ",
+    "streakShieldActivate": "Activează Scutul",
+    "streakShieldCost": "Cost: 500 XP",
+    "streakShieldNotEnoughXP": "XP insuficient (necesită 500)",
+    "streakShieldConfirm": "Cheltuiești 500 XP pentru a activa Scutul Seriei?",
     "newCardsPerDay": "Carduri noi pe zi",
     "cardsCount": "{{count}} carduri"
   },
@@ -40,7 +46,10 @@
   },
   "actions": {
     "saveChanges": "Salvează modificările",
-    "cancel": "Anulează"
+    "cancel": "Anulează",
+    "saveSuccess": "Modificările au fost salvate cu succes",
+    "saveError": "Eroare la salvare",
+    "saveErrorDesc": "Te rog încearcă din nou"
   },
   "appearance": {
     "title": "Aspect",

--- a/server/db/schema.sql
+++ b/server/db/schema.sql
@@ -53,6 +53,10 @@ CREATE TABLE users (
     total_correct_answers INTEGER DEFAULT 0,
     total_answers INTEGER DEFAULT 0,
 
+    -- Streak Shield
+    streak_shield_active BOOLEAN DEFAULT false,
+    streak_shield_used_date DATE,
+
     -- Preferences (JSON)
     preferences JSONB DEFAULT '{
         "dailyGoal": 20,
@@ -426,6 +430,7 @@ CREATE TABLE daily_challenges (
     cards_reward_claimed BOOLEAN DEFAULT false,
     time_reward_claimed BOOLEAN DEFAULT false,
     streak_reward_claimed BOOLEAN DEFAULT false,
+    daily_xp_reward_claimed BOOLEAN DEFAULT false,
 
     -- Metadata
     created_at TIMESTAMP WITH TIME ZONE DEFAULT NOW(),

--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -56,3 +56,9 @@ export interface CardStats {
 export async function getUserCardStats(userId: string) {
   return api.get<CardStats>(`/users/${userId}/card-stats`);
 }
+
+export async function activateStreakShield(userId: string) {
+  return api.post<{ streakShieldActive: boolean; xpDeducted: number }>(
+    `/users/${userId}/activate-streak-shield`
+  );
+}

--- a/src/components/pages/Dashboard/Dashboard.tsx
+++ b/src/components/pages/Dashboard/Dashboard.tsx
@@ -25,6 +25,7 @@ import {
   ChevronRight,
   Crown,
   Sparkles,
+  ShieldCheck,
 } from 'lucide-react';
 import {
   AreaChart,
@@ -191,6 +192,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
       BookOpen,
       Clock,
       Flame,
+      Zap,
     };
     return icons[iconName] || BookOpen;
   };
@@ -379,7 +381,15 @@ export const Dashboard: React.FC<DashboardProps> = ({
               <Flame size={120} />
             </div>
             <div className="relative z-10 flex flex-col">
-              <div className="text-5xl font-bold mb-2">{stats.streak}</div>
+              <div className="flex items-center gap-3">
+                <div className="text-5xl font-bold mb-2">{stats.streak}</div>
+                {user.streakShieldActive && (
+                  <div className="flex items-center gap-1 bg-white/20 backdrop-blur-sm px-2.5 py-1 rounded-full text-xs font-bold mb-2">
+                    <ShieldCheck size={14} />
+                    {t('stats.shieldActive', 'Protected')}
+                  </div>
+                )}
+              </div>
               <div className="text-base font-bold mb-1">{t('stats.streak')}</div>
               <div className="text-sm opacity-90">
                 {t('stats.streakRecord', { days: stats.longestStreak })}

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -189,6 +189,7 @@ export interface User {
   // Stats
   streak: number;
   longestStreak: number;
+  streakShieldActive?: boolean;
   lastActiveDate?: string;
   totalTimeSpent: number; // Minutes
   totalCardsLearned: number;
@@ -205,6 +206,7 @@ export interface User {
 
 export interface UserPreferences {
   dailyGoal: number; // Cards per day
+  dailyXPGoal?: number; // Daily XP target (min 100)
   reminderTime?: string; // HH:mm format
   soundEnabled: boolean;
   animationsEnabled: boolean;


### PR DESCRIPTION
…ence

Replace non-functional Focus Mode / Shuffle Cards with real gamification:

- Daily XP Goal Tracker: configurable slider (100-1000 XP), dynamic bonus (0.01 * goal), celebration animation during session when goal is hit, persistent via sessionStorage + daily_challenges table
- Streak Shield: costs 500 XP, protects streak for 1 missed day, integrated with calculateStreakFromDailyProgress, visual badge on dashboard streak card
- Fix achievement persistence: force immediate server sync when client detects achievement during session (prevents animation-without-save bug)

Backend changes:
- Schema: streak_shield_active, streak_shield_used_date on users; daily_xp_reward_claimed on daily_challenges
- Routes: POST /users/:id/activate-streak-shield endpoint
- Auth: streak calculation respects shield (bridges 1-day gap)
- Daily challenges: 4th challenge type (daily_xp) with dynamic reward
- Session completion: passes shield state to streak calc

Frontend changes:
- Settings: Daily XP Goal slider + Streak Shield activation card
- Dashboard: ShieldCheck badge on streak card when shield active
- Session: daily XP goal celebration + forced achievement sync
- Types: dailyXPGoal in UserPreferences, streakShieldActive on User
- i18n: all 3 languages (EN, RO, IT) updated

https://claude.ai/code/session_01APhKeK1tF9urpsWq9rJJFg