### PR TITLE
feat: settings reorganization, dashboard badges, leaderboard avatars

### DIFF
--- a/src/api/users.ts
+++ b/src/api/users.ts
@@ -9,6 +9,7 @@ export interface LeaderboardEntry {
   id: string;
   position: number;
   name: string;
+  avatar?: string;
   level: number;
   xpTotal: number;
   streak: number;
@@ -61,4 +62,8 @@ export async function activateStreakShield(userId: string) {
   return api.post<{ streakShieldActive: boolean; xpDeducted: number }>(
     `/users/${userId}/activate-streak-shield`
   );
+}
+
+export async function deactivateStreakShield(userId: string) {
+  return api.post<{ streakShieldActive: boolean }>(`/users/${userId}/deactivate-streak-shield`);
 }

--- a/src/components/pages/Dashboard/Dashboard.tsx
+++ b/src/components/pages/Dashboard/Dashboard.tsx
@@ -209,6 +209,17 @@ export const Dashboard: React.FC<DashboardProps> = ({
       diamond: '💎',
       crown: '👑',
       calendar: '📅',
+      moon: '🌙',
+      sunrise: '🌅',
+      award: '🏅',
+      trophy: '🏆',
+      medal: '🎖️',
+      coins: '🪙',
+      gem: '💠',
+      sparkles: '✨',
+      timer: '⏱️',
+      brain: '🧠',
+      'book-check': '📖',
     };
     return emojiMap[iconName] || '🏆';
   };
@@ -226,6 +237,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
       .map(a => ({
         icon: getAchievementEmoji(a.icon),
         title: a.title,
+        xpReward: a.xpReward,
       }));
   }, [achievements]);
 
@@ -854,7 +866,12 @@ export const Dashboard: React.FC<DashboardProps> = ({
                         {t('recentAchievements.unlockedRecently')}
                       </p>
                     </div>
-                    <Star className="text-yellow-500" size={20} fill="#EAB308" />
+                    <div className="flex items-center gap-1 px-2 py-1 rounded-lg bg-yellow-500/10">
+                      <Zap size={14} className="text-yellow-500" />
+                      <span className="text-xs font-bold text-yellow-500">
+                        +{achievement.xpReward}
+                      </span>
+                    </div>
                   </div>
                 ))
               ) : (

--- a/src/components/pages/Leaderboard/Leaderboard.tsx
+++ b/src/components/pages/Leaderboard/Leaderboard.tsx
@@ -2,7 +2,8 @@ import React, { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { User } from '../../../types';
 import { LeaderboardEntry } from '../../../api/users';
-import { Flame, Medal, Users } from 'lucide-react';
+import { Flame, Medal, Trophy, Users } from 'lucide-react';
+import { AVATARS } from '../Settings/AvatarPicker';
 
 interface LeaderboardProps {
   entries: LeaderboardEntry[];
@@ -142,7 +143,9 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({
       {/* Leaderboard Table */}
       <div className="bg-[var(--card-bg)] rounded-2xl shadow-sm overflow-hidden">
         <div className="grid grid-cols-12 gap-4 p-4 border-b border-[var(--border-subtle)] bg-[var(--bg-tertiary)] text-[var(--text-tertiary)] font-bold text-sm">
-          <div className="col-span-2 md:col-span-1 text-center">{t('table.position')}</div>
+          <div className="col-span-2 md:col-span-1 flex items-center justify-center gap-1">
+            <Trophy size={14} className="text-yellow-500" />
+          </div>
           <div className="col-span-6 md:col-span-5">{t('table.user')}</div>
           <div className="col-span-2 text-center hidden md:block">{t('table.level')}</div>
           <div className="col-span-2 text-center">{t('table.totalXP')}</div>
@@ -166,12 +169,13 @@ export const Leaderboard: React.FC<LeaderboardProps> = ({
             </div>
 
             <div className="col-span-6 md:col-span-5 flex items-center gap-3">
-              <div className="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-sm font-bold text-[var(--text-secondary)]">
-                {entry.name
-                  .split(' ')
-                  .map(n => n[0])
-                  .join('')
-                  .toUpperCase()}
+              <div className="w-10 h-10 rounded-full bg-[var(--bg-tertiary)] flex items-center justify-center text-lg font-bold text-[var(--text-secondary)]">
+                {entry.avatar && entry.avatar !== 'default'
+                  ? (() => {
+                      const av = AVATARS.find(a => a.id === entry.avatar);
+                      return av ? av.emoji : entry.name.charAt(0).toUpperCase();
+                    })()
+                  : entry.name.charAt(0).toUpperCase()}
               </div>
               <div>
                 <p

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -207,6 +207,7 @@ export interface User {
 export interface UserPreferences {
   dailyGoal: number; // Cards per day
   dailyXPGoal?: number; // Daily XP target (min 100)
+  hideFromLeaderboard?: boolean; // Hide profile from leaderboard
   reminderTime?: string; // HH:mm format
   soundEnabled: boolean;
   animationsEnabled: boolean;


### PR DESCRIPTION
Settings:
- Move language selector to right column under Appearance
- Add streak shield deactivation button
- Change XP bonus multiplier from 0.01 to 0.1
- Replace "New cards per day" with leaderboard visibility toggle

Dashboard:
- Fix achievement emoji map (all 19 icons, was only 8)
- Show XP reward amount instead of generic star icon

Leaderboard:
- Show user avatar emoji instead of name initials
- Show trophy icon in position column header
- Filter hidden users from leaderboard (via preferences)

Backend:
- Add POST /users/:id/deactivate-streak-shield endpoint
- Filter leaderboard by hideFromLeaderboard preference

https://claude.ai/code/session_01W4CnJLGB98mpceFVzZj2A9