### PR TITLE
fix: daily challenges XP multiplier, sidebar XP label and badge sizes

### DIFF
--- a/public/locales/en/sidebar.json
+++ b/public/locales/en/sidebar.json
@@ -18,7 +18,7 @@
   "xp": {
     "label": "XP",
     "level": "Level {{level}}",
-    "totalXP": "{{xp}} total XP",
+    "totalXP": "{{xp}} XP",
     "progress": "{{current}} / {{next}}"
   },
   "nightMode": {

--- a/public/locales/it/sidebar.json
+++ b/public/locales/it/sidebar.json
@@ -18,7 +18,7 @@
   "xp": {
     "label": "XP",
     "level": "Livello {{level}}",
-    "totalXP": "{{xp}} XP totali",
+    "totalXP": "{{xp}} XP",
     "progress": "{{current}} / {{next}}"
   },
   "nightMode": {

--- a/public/locales/ro/sidebar.json
+++ b/public/locales/ro/sidebar.json
@@ -18,7 +18,7 @@
   "xp": {
     "label": "XP",
     "level": "Nivel {{level}}",
-    "totalXP": "{{xp}} XP total",
+    "totalXP": "{{xp}} XP",
     "progress": "{{current}} / {{next}}"
   },
   "nightMode": {

--- a/server/routes/dailyChallenges.ts
+++ b/server/routes/dailyChallenges.ts
@@ -121,7 +121,7 @@ router.get('/today', authenticateToken, async (req, res) => {
             target: dailyXPGoal,
             completed: todayXPEarned >= dailyXPGoal,
             rewardClaimed: challenge.daily_xp_reward_claimed || false,
-            reward: Math.floor(dailyXPGoal * 0.01),
+            reward: Math.floor(dailyXPGoal * 0.1),
             icon: 'Zap',
             color: 'from-yellow-500 to-amber-600',
           },
@@ -218,7 +218,7 @@ router.post('/claim-reward', authenticateToken, async (req, res) => {
       const todayXPEarned = xpResult.rows.length > 0 ? parseInt(xpResult.rows[0].xp_earned) : 0;
 
       isCompleted = todayXPEarned >= dailyXPGoal;
-      rewardXP = Math.floor(dailyXPGoal * 0.01);
+      rewardXP = Math.floor(dailyXPGoal * 0.1);
     }
 
     if (!isCompleted) {

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -181,11 +181,11 @@ export const Sidebar: React.FC<SidebarProps> = ({
 
         {/* Recent Badges - below name, before XP bar */}
         {!isGuest && recentBadges.length > 0 && (
-          <div className="flex items-center gap-1.5 mb-4 ml-1">
+          <div className="flex items-center gap-2 mb-4">
             {recentBadges.map(badge => (
               <div
                 key={badge.id}
-                className="w-7 h-7 rounded-lg flex items-center justify-center text-sm"
+                className="flex-1 h-9 rounded-lg flex items-center justify-center text-lg"
                 style={{ backgroundColor: 'var(--bg-tertiary)' }}
                 title={badge.title}
               >


### PR DESCRIPTION
- Fix XP bonus multiplier in dailyChallenges.ts (0.01 → 0.1) to match settings
- Remove word "total" from sidebar XP display across all locales
- Increase achievement badge dimensions to fill horizontal space

https://claude.ai/code/session_01W4CnJLGB98mpceFVzZj2A9