### PR TITLE
Shuffle answer options in quiz and multiple-answer cards

### DIFF
--- a/src/components/study-session/cards/MultipleAnswerCard.tsx
+++ b/src/components/study-session/cards/MultipleAnswerCard.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react';
 import { CardActionsMenu } from '../menus/CardActionsMenu';
 import { HintOverlay } from '../shared/HintOverlay';
+import { shuffleIndices } from '../../../utils/shuffle';
 
 interface MultipleAnswerCardProps {
   card: Card;
@@ -63,6 +64,8 @@ export const MultipleAnswerCard: React.FC<MultipleAnswerCardProps> = ({
   const [hasAnswered, setHasAnswered] = React.useState(hasAnsweredProp);
   const [isCorrect, setIsCorrect] = React.useState<boolean | null>(null);
   const [autoAdvanceTimer, setAutoAdvanceTimer] = React.useState<NodeJS.Timeout | null>(null);
+
+  const shuffledIndices = React.useMemo(() => shuffleIndices(card.options?.length ?? 0), [card.id]);
 
   // Reset local state when card changes
   React.useEffect(() => {
@@ -234,17 +237,18 @@ export const MultipleAnswerCard: React.FC<MultipleAnswerCardProps> = ({
 
           {/* Options with Checkboxes */}
           <div className="flex flex-col gap-3">
-            {card.options?.map((option, index) => {
-              const isSelected = selectedMultipleOptions.includes(index);
-              const isCorrectOption = correctIndices.includes(index);
+            {shuffledIndices.map(dataIndex => {
+              const option = card.options?.[dataIndex];
+              const isSelected = selectedMultipleOptions.includes(dataIndex);
+              const isCorrectOption = correctIndices.includes(dataIndex);
               const showCorrectHighlight = showResult && isCorrectOption;
               const showIncorrect = showResult && isSelected && !isCorrectOption;
               const showMissed = showResult && isCorrectOption && !isSelected;
 
               return (
                 <button
-                  key={index}
-                  onClick={() => handleOptionToggle(index)}
+                  key={dataIndex}
+                  onClick={() => handleOptionToggle(dataIndex)}
                   disabled={isAnswered}
                   className={`w-full text-left p-4 rounded-xl border-2 transition-all font-medium ${
                     showCorrectHighlight

--- a/src/components/study-session/cards/QuizCard.tsx
+++ b/src/components/study-session/cards/QuizCard.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react';
 import { CardActionsMenu } from '../menus/CardActionsMenu';
 import { HintOverlay } from '../shared/HintOverlay';
+import { shuffleIndices } from '../../../utils/shuffle';
 
 interface QuizCardProps {
   card: Card;
@@ -53,6 +54,8 @@ export const QuizCard: React.FC<QuizCardProps> = ({
   const [hasAnswered, setHasAnswered] = React.useState(hasAnsweredProp);
   const [isCorrect, setIsCorrect] = React.useState<boolean | null>(null);
   const [autoAdvanceTimer, setAutoAdvanceTimer] = React.useState<NodeJS.Timeout | null>(null);
+
+  const shuffledIndices = React.useMemo(() => shuffleIndices(card.options?.length ?? 0), [card.id]);
 
   // Reset local state when card changes (enables re-visit practice)
   React.useEffect(() => {
@@ -187,16 +190,17 @@ export const QuizCard: React.FC<QuizCardProps> = ({
 
           {/* Options - flex column with proper gap */}
           <div className="flex flex-col gap-3">
-            {card.options?.map((option, index) => {
-              const isSelected = selectedQuizOption === index;
-              const isCorrectOption = index === card.correctOptionIndices?.[0];
+            {shuffledIndices.map(dataIndex => {
+              const option = card.options?.[dataIndex];
+              const isSelected = selectedQuizOption === dataIndex;
+              const isCorrectOption = dataIndex === card.correctOptionIndices?.[0];
               const showCorrect = showResult && isCorrectOption;
               const showIncorrect = showResult && isSelected && !isCorrectOption;
 
               return (
                 <button
-                  key={index}
-                  onClick={() => handleOptionClick(index)}
+                  key={dataIndex}
+                  onClick={() => handleOptionClick(dataIndex)}
                   disabled={isAnswered}
                   className={`w-full text-left p-4 rounded-xl border-2 transition-all font-medium ${
                     showCorrect

--- a/src/utils/shuffle.ts
+++ b/src/utils/shuffle.ts
@@ -1,0 +1,12 @@
+/**
+ * Generates an array of shuffled indices using the Fisher-Yates algorithm.
+ * Returns [0, 1, 2, ..., length-1] in a random order.
+ */
+export function shuffleIndices(length: number): number[] {
+  const indices = Array.from({ length }, (_, i) => i);
+  for (let i = indices.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [indices[i], indices[j]] = [indices[j], indices[i]];
+  }
+  return indices;
+}


### PR DESCRIPTION
## Summary
This PR randomizes the order of answer options displayed in quiz and multiple-answer study cards to prevent users from relying on positional patterns when answering questions.

## Changes
- **New utility function**: Added `shuffleIndices()` in `src/utils/shuffle.ts` that implements the Fisher-Yates algorithm to generate a randomized array of indices
- **QuizCard component**: Modified to shuffle and display options in random order while maintaining correct answer tracking using original indices
- **MultipleAnswerCard component**: Applied the same shuffling logic for consistency across card types
- Both components now use `React.useMemo` to memoize shuffled indices based on `card.id`, ensuring the shuffle order remains stable during a card's lifecycle but changes when moving to a different card

## Implementation Details
- The shuffle is performed on indices rather than the options themselves, preserving the original data structure and correct answer references
- Memoization ensures the shuffle happens once per card and doesn't recalculate on every render
- All click handlers and selection logic correctly map between the shuffled display order and the original data indices

https://claude.ai/code/session_01E41C7qRHMjmt8fDSmdmc8b