### PR TITLE
fix(feedback): portal rendering, screenshot capture, and env diagnostics

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -153,6 +153,7 @@ app.listen(PORT, () => {
 ║  Port:      ${PORT}                            ║
 ║  Env:       ${config.nodeEnv.padEnd(28)}║
 ║  Database:  PostgreSQL                     ║
+║  GitHub:    ${config.github.token ? 'Configured ✓' : 'NOT configured ✗'}                  ║
 ╚════════════════════════════════════════════╝
   `);
 });

--- a/server/routes/feedback.ts
+++ b/server/routes/feedback.ts
@@ -149,11 +149,13 @@ router.post('/bug', authenticateToken, async (req: Request, res: Response) => {
     // Check GitHub configuration
     const { token, repo } = config.github;
     if (!token || !repo) {
+      const missing = [!token && 'GITHUB_TOKEN', !repo && 'GITHUB_REPO'].filter(Boolean);
+      console.error('Bug report service not configured. Missing env vars:', missing.join(', '));
       return res.status(503).json({
         success: false,
         error: {
           code: 'SERVICE_UNAVAILABLE',
-          message: 'Sistemul de raportare nu este configurat. Contactați administratorul.',
+          message: `Sistemul de raportare nu este configurat. Variabile lipsă: ${missing.join(', ')}`,
         },
       });
     }


### PR DESCRIPTION
1. Render BugReportModal via ReactDOM.createPortal to document.body so it's not clipped by the sidebar's w-64 container.
2. Fix html2canvas "0 width/height" error by hiding overlay via style.display instead of unmounting, and targeting document.documentElement with explicit dimensions.
3. Add diagnostic logging for missing GITHUB_TOKEN/GITHUB_REPO env vars (startup banner + 503 error message).

https://claude.ai/code/session_01E41C7qRHMjmt8fDSmdmc8b