### PR TITLE
fix(feedback): portal rendering, screenshot capture, and env diagnostics

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -73,6 +73,11 @@ app.get('/api/health', async (req, res) => {
     status: dbHealthy ? 'healthy' : 'unhealthy',
     timestamp: new Date().toISOString(),
     database: dbHealthy ? 'connected' : 'disconnected',
+    github: {
+      tokenSet: !!config.github.token,
+      repoSet: !!config.github.repo,
+      repo: config.github.repo || null,
+    },
   });
 });
 

--- a/src/components/feedback/BugReportModal.tsx
+++ b/src/components/feedback/BugReportModal.tsx
@@ -61,6 +61,15 @@ export const BugReportModal: React.FC<BugReportModalProps> = ({ onClose }) => {
         height: window.innerHeight,
         windowWidth: window.innerWidth,
         windowHeight: window.innerHeight,
+        onclone: (clonedDoc: Document) => {
+          // Remove zero-dimension canvas elements (e.g. from recharts) that cause
+          // "createPattern" InvalidStateError in html2canvas
+          clonedDoc.querySelectorAll('canvas').forEach(c => {
+            if (c.width === 0 || c.height === 0) {
+              c.remove();
+            }
+          });
+        },
       });
       const dataUrl = canvas.toDataURL('image/png');
       setScreenshot(dataUrl);


### PR DESCRIPTION
1. Render BugReportModal via ReactDOM.createPortal to document.body so it's not clipped by the sidebar's w-64 container.
2. Fix html2canvas "0 width/height" error by hiding overlay via style.display instead of unmounting, and targeting document.documentElement with explicit dimensions.
3. Add diagnostic logging for missing GITHUB_TOKEN/GITHUB_REPO env vars (startup banner + 503 error message).

https://claude.ai/code/session_01E41C7qRHMjmt8fDSmdmc8b