### PR TITLE
fix(server): use local timezone for all date computations

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -73,7 +73,7 @@ jobs:
             --min-instances 0 \
             --max-instances 10 \
             --add-cloudsql-instances ${{ env.PROJECT_ID }}:${{ env.REGION }}:flashcards-db \
-            --set-env-vars "NODE_ENV=production,CORS_ORIGIN=*,DB_HOST=/cloudsql/${{ env.PROJECT_ID }}:${{ env.REGION }}:flashcards-db,DB_PORT=5432,DB_NAME=flashcards,DB_USER=flashcards_user,GITHUB_REPO=NoisimRo/Flashcards" \
+            --set-env-vars "NODE_ENV=production,CORS_ORIGIN=*,DB_HOST=/cloudsql/${{ env.PROJECT_ID }}:${{ env.REGION }}:flashcards-db,DB_PORT=5432,DB_NAME=flashcards,DB_USER=flashcards_user,GITHUB_REPO=NoisimRo/Flashcards,TZ=Europe/Bucharest" \
             --set-secrets "DB_PASSWORD=flashcards-db-password:latest,JWT_ACCESS_SECRET=flashcards-jwt-access:latest,JWT_REFRESH_SECRET=flashcards-jwt-refresh:latest,GITHUB_TOKEN=GITHUB_TOKEN:latest"
 
       - name: Show deployment URL

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -95,7 +95,7 @@ steps:
       - '--add-cloudsql-instances'
       - '${PROJECT_ID}:${_REGION}:flashcards-db'
       - '--set-env-vars'
-      - 'NODE_ENV=production,CORS_ORIGIN=*,DB_HOST=/cloudsql/${PROJECT_ID}:${_REGION}:flashcards-db,DB_PORT=5432,DB_NAME=flashcards,DB_USER=flashcards_user,GITHUB_REPO=NoisimRo/Flashcards'
+      - 'NODE_ENV=production,CORS_ORIGIN=*,DB_HOST=/cloudsql/${PROJECT_ID}:${_REGION}:flashcards-db,DB_PORT=5432,DB_NAME=flashcards,DB_USER=flashcards_user,GITHUB_REPO=NoisimRo/Flashcards,TZ=Europe/Bucharest'
       - '--set-secrets'
       - 'DB_PASSWORD=flashcards-db-password:latest,JWT_ACCESS_SECRET=flashcards-jwt-access:latest,JWT_REFRESH_SECRET=flashcards-jwt-refresh:latest,GEMINI_API_KEY=flashcards-gem-key:latest,GITHUB_TOKEN=GITHUB_TOKEN:latest'
     id: 'deploy'

--- a/server/routes/achievements.ts
+++ b/server/routes/achievements.ts
@@ -1,6 +1,7 @@
 import express from 'express';
 import { query } from '../db/index.js';
 import { authenticateToken } from '../middleware/auth.js';
+import { getLocalToday } from '../utils/timezone.js';
 
 const router = express.Router();
 
@@ -274,7 +275,7 @@ export async function checkAndUnlockAchievements(
         user.next_level_xp = newNextLevelXP;
 
         // Record achievement XP in daily_progress
-        const today = new Date().toISOString().split('T')[0];
+        const today = getLocalToday();
         await client.query(
           `INSERT INTO daily_progress (user_id, date, xp_earned)
            VALUES ($1, $2, $3)

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1,6 +1,7 @@
 import { Router, Request, Response } from 'express';
 import { query } from '../db/index.js';
 import { authenticateToken, requireRole } from '../middleware/auth.js';
+import { getLocalToday } from '../utils/timezone.js';
 
 const router = Router();
 
@@ -761,12 +762,13 @@ router.get('/:id/stats', authenticateToken, async (req: Request, res: Response) 
     }
 
     // Get weekly progress
+    const todayStr = getLocalToday();
     const weeklyResult = await query(
       `SELECT date, cards_studied, cards_learned, time_spent_minutes, xp_earned
        FROM daily_progress
-       WHERE user_id = $1 AND date >= CURRENT_DATE - INTERVAL '7 days'
+       WHERE user_id = $1 AND date >= $2::date - INTERVAL '7 days'
        ORDER BY date ASC`,
-      [id]
+      [id, todayStr]
     );
 
     // Get achievements

--- a/server/services/cardSelectionService.ts
+++ b/server/services/cardSelectionService.ts
@@ -2,6 +2,7 @@
  * Card Selection Service
  * Handles logic for selecting cards for study sessions
  */
+import { getLocalToday } from '../utils/timezone.js';
 
 interface Card {
   id: string;
@@ -115,7 +116,7 @@ function selectSmart(
   progressMap: Map<string, UserCardProgress>,
   count: number
 ): Card[] {
-  const today = new Date().toISOString().split('T')[0];
+  const today = getLocalToday();
 
   // Categorize cards
   const dueCards: Card[] = [];
@@ -260,10 +261,10 @@ export function calculateSM2Update(
     repetitions++;
   }
 
-  // Calculate next review date
-  const nextDate = new Date();
+  // Calculate next review date using local date (respects TZ env var)
+  const nextDate = new Date(getLocalToday() + 'T12:00:00');
   nextDate.setDate(nextDate.getDate() + interval);
-  const nextReviewDate = nextDate.toISOString().split('T')[0];
+  const nextReviewDate = `${nextDate.getFullYear()}-${String(nextDate.getMonth() + 1).padStart(2, '0')}-${String(nextDate.getDate()).padStart(2, '0')}`;
 
   // Determine status
   let status: 'new' | 'learning' | 'reviewing' | 'mastered';

--- a/server/utils/timezone.ts
+++ b/server/utils/timezone.ts
@@ -1,0 +1,43 @@
+/**
+ * Timezone utility for computing the user's local date.
+ *
+ * Cloud Run defaults to UTC, but users are in Romania (UTC+2 / UTC+3 DST).
+ * `new Date().toISOString().split('T')[0]` always returns the UTC date,
+ * which can be a day behind the user's local date between midnight and
+ * 2-3 AM local time. This utility computes the correct local date.
+ *
+ * Priority:
+ *   1. clientTimezoneOffset (from frontend's new Date().getTimezoneOffset())
+ *   2. TZ environment variable (set to Europe/Bucharest in Cloud Run)
+ */
+
+/**
+ * Returns the current date string (YYYY-MM-DD) in the user's local timezone.
+ */
+export function getLocalToday(clientTimezoneOffset?: number | null): string {
+  const now = new Date();
+
+  if (clientTimezoneOffset != null) {
+    // getTimezoneOffset() returns minutes where UTC+2 → -120
+    // Shift UTC time by the offset to get local time
+    const localMs = now.getTime() - clientTimezoneOffset * 60 * 1000;
+    const local = new Date(localMs);
+    return local.toISOString().split('T')[0];
+  }
+
+  // Fallback: use server's local date (respects TZ env var)
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+}
+
+/**
+ * Returns the user's local hour (0-23).
+ */
+export function getLocalHour(clientTimezoneOffset?: number | null): number {
+  if (clientTimezoneOffset != null) {
+    return Math.floor((((new Date().getUTCHours() - clientTimezoneOffset / 60) % 24) + 24) % 24);
+  }
+  return new Date().getHours();
+}


### PR DESCRIPTION
Server was using new Date().toISOString().split('T')[0] which always returns UTC date. For Romanian users (UTC+2), daily challenges wouldn't reset until 2AM local time, streaks miscounted, and card reviews were off by a day near midnight.

- Create server/utils/timezone.ts with getLocalToday() and getLocalHour()
- Replace all toISOString().split('T')[0] with getLocalToday() in: dailyChallenges, studySessions, auth, achievements, users, cardSelection
- Replace CURRENT_DATE in SQL with parameterized local dates
- Fix streak calculation to use noon-anchored dates (DST-safe)
- Add TZ=Europe/Bucharest to Cloud Run deploy configs

Closes #124

https://claude.ai/code/session_01E41C7qRHMjmt8fDSmdmc8b