### PR TITLE
fix(dashboard): use local date for today's study time matching

### DIFF
--- a/src/components/pages/Dashboard/Dashboard.tsx
+++ b/src/components/pages/Dashboard/Dashboard.tsx
@@ -245,7 +245,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
   // Calculate today's and weekly study time from activity calendar
   const studyTimeStats = useMemo(() => {
     const today = new Date();
-    const todayStr = today.toISOString().split('T')[0];
+    const todayStr = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
 
     // Get today's time
     const todayActivity = activityCalendar.find(day => day.date === todayStr);


### PR DESCRIPTION
The study time tile used toISOString().split('T')[0] which returns UTC date, causing a mismatch with activity calendar entries between midnight and 2AM Romanian time. Now uses getFullYear/getMonth/getDate for correct local date.

https://claude.ai/code/session_01E41C7qRHMjmt8fDSmdmc8b