### PR TITLE
Remove session completion modal trigger logic

### DIFF
--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -172,22 +172,6 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
     }
   }, [user]);
 
-  // Check if session is complete (all cards answered)
-  useEffect(() => {
-    if (!currentSession?.cards) return;
-
-    const totalCards = currentSession.cards.length;
-    const answeredCards = Object.keys(answers).length;
-
-    // Show completion modal when all cards are answered
-    // SINGLE SOURCE OF TRUTH - prevents double completion calls
-    if (answeredCards === totalCards && totalCards > 0 && !showCompletionModal) {
-      setTimeout(() => {
-        setShowCompletionModal(true);
-      }, 6000); // 6 seconds delay to let user read feedback and explanation on last card
-    }
-  }, [answers, currentSession, showCompletionModal]);
-
   // Handle back navigation with progress sync
   const handleBack = async () => {
     await syncProgress();


### PR DESCRIPTION
## Summary
Removed the `useEffect` hook that automatically triggered the session completion modal when all cards in a study session were answered.

## Changes
- Deleted the completion detection logic that monitored the `answers` object and compared answered cards against total cards
- Removed the 6-second delay timeout that was intended to allow users to read feedback on the final card before showing the completion modal
- Eliminated the `showCompletionModal` dependency from the effect hook

## Notes
This change suggests that session completion is now being handled through an alternative mechanism (likely triggered explicitly by user action or moved to a different component/hook). The completion modal display logic may have been consolidated or refactored to prevent duplicate completion calls through a different approach.

https://claude.ai/code/session_01UsoPjkY4u6JDvJ41DgmdL4