### PR TITLE
fix(study-session): increase last-card timer 3x and fix silent comple…

### DIFF
--- a/src/components/study-session/cards/MultipleAnswerCard.tsx
+++ b/src/components/study-session/cards/MultipleAnswerCard.tsx
@@ -131,11 +131,12 @@ export const MultipleAnswerCard: React.FC<MultipleAnswerCardProps> = ({
       onAnswer(correct);
     }, 100);
 
-    // Auto-advance after 10 seconds to allow time for reading the explanation
+    // Auto-advance: 10s normally, 30s on last card so user can read feedback
     if (onAutoAdvance) {
+      const delay = isLastCard ? 30000 : 10000;
       const timer = setTimeout(() => {
         onAutoAdvance();
-      }, 10000);
+      }, delay);
       setAutoAdvanceTimer(timer);
     }
   };

--- a/src/components/study-session/cards/QuizCard.tsx
+++ b/src/components/study-session/cards/QuizCard.tsx
@@ -90,11 +90,12 @@ export const QuizCard: React.FC<QuizCardProps> = ({
       onAnswer(correct);
     }, 100);
 
-    // Auto-advance after 3 seconds
+    // Auto-advance: 3s normally, 9s on last card so user can read feedback
     if (onAutoAdvance) {
+      const delay = isLastCard ? 9000 : 3000;
       const timer = setTimeout(() => {
         onAutoAdvance();
-      }, 3000);
+      }, delay);
       setAutoAdvanceTimer(timer);
     }
   };

--- a/src/components/study-session/cards/TypeAnswerCard.tsx
+++ b/src/components/study-session/cards/TypeAnswerCard.tsx
@@ -183,11 +183,12 @@ export const TypeAnswerCard: React.FC<TypeAnswerCardProps> = ({
       setShowBack(true);
     }, 500);
 
-    // Auto-advance after 3 seconds (from back view)
+    // Auto-advance: 3.5s normally, 10.5s on last card so user can read feedback
     if (onAutoAdvance) {
+      const delay = isLastCard ? 10500 : 3500; // 500ms feedback + viewing time
       const timer = setTimeout(() => {
         onAutoAdvance();
-      }, 3500); // 500ms feedback + 3000ms on back = 3500ms total
+      }, delay);
       setAutoAdvanceTimer(timer);
     }
   };


### PR DESCRIPTION
…tion failure

Timer changes (last card only, non-last cards unchanged):
- QuizCard: 3s → 9s on last card
- TypeAnswerCard: 3.5s → 10.5s on last card
- MultipleAnswerCard: 10s → 30s on last card

Fix handleFinishAndExit: completeSession() catches its own errors and returns null instead of throwing, so the catch block was dead code. When the API failed, the else branch ran silently, navigating the user away without the session being marked as completed. Now properly checks for null result and shows an error, keeping the modal open for retry.

https://claude.ai/code/session_01UsoPjkY4u6JDvJ41DgmdL4