### PR TITLE
fix(dashboard,cards): chart theming, tooltip fix, calendar corners

### DIFF
--- a/src/components/pages/Dashboard/Dashboard.tsx
+++ b/src/components/pages/Dashboard/Dashboard.tsx
@@ -629,7 +629,7 @@ export const Dashboard: React.FC<DashboardProps> = ({
                 return (
                   <div
                     key={idx}
-                    className="aspect-square rounded-sm transition-all hover:scale-110 cursor-pointer"
+                    className="aspect-square rounded-md transition-all hover:scale-110 cursor-pointer"
                     style={
                       day.intensity === 0
                         ? { backgroundColor: 'var(--bg-tertiary)' }
@@ -703,21 +703,24 @@ export const Dashboard: React.FC<DashboardProps> = ({
                         />
                         <RechartsTooltip
                           cursor={false}
-                          contentStyle={{
-                            backgroundColor: 'var(--bg-elevated)',
-                            border: '1px solid var(--border-secondary)',
-                            borderRadius: '8px',
-                            fontSize: '11px',
-                            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
-                            padding: '6px 10px',
+                          content={({ active, payload, label }) => {
+                            if (!active || !payload?.length) return null;
+                            return (
+                              <div
+                                className="rounded-lg text-xs shadow-lg border px-2.5 py-1.5"
+                                style={{
+                                  backgroundColor: 'var(--bg-elevated)',
+                                  borderColor: 'var(--border-secondary)',
+                                  color: 'var(--text-primary)',
+                                }}
+                              >
+                                <div style={{ color: 'var(--text-muted)' }}>{label}</div>
+                                <div className="font-semibold">
+                                  {payload[0].value} {t('stats.minutes', 'min')}
+                                </div>
+                              </div>
+                            );
                           }}
-                          itemStyle={{ color: 'var(--text-primary)' }}
-                          labelStyle={{ color: 'var(--text-secondary)', marginBottom: '2px' }}
-                          formatter={(value: number) => [
-                            `${value} ${t('stats.minutes', 'min')}`,
-                            t('activityCalendar.timeSpentChart'),
-                          ]}
-                          labelFormatter={(label: string) => label}
                         />
                         <Area
                           type="monotone"
@@ -755,8 +758,8 @@ export const Dashboard: React.FC<DashboardProps> = ({
                       >
                         <defs>
                           <linearGradient id="barGradient" x1="0" y1="0" x2="0" y2="1">
-                            <stop offset="5%" stopColor="#22c55e" stopOpacity={0.8} />
-                            <stop offset="95%" stopColor="#22c55e" stopOpacity={0.3} />
+                            <stop offset="5%" stopColor="var(--color-accent)" stopOpacity={0.8} />
+                            <stop offset="95%" stopColor="var(--color-accent)" stopOpacity={0.3} />
                           </linearGradient>
                         </defs>
                         <XAxis dataKey="date" hide />
@@ -769,21 +772,22 @@ export const Dashboard: React.FC<DashboardProps> = ({
                         />
                         <RechartsTooltip
                           cursor={false}
-                          contentStyle={{
-                            backgroundColor: 'var(--bg-elevated)',
-                            border: '1px solid var(--border-secondary)',
-                            borderRadius: '8px',
-                            fontSize: '11px',
-                            boxShadow: '0 4px 12px rgba(0,0,0,0.3)',
-                            padding: '6px 10px',
+                          content={({ active, payload, label }) => {
+                            if (!active || !payload?.length) return null;
+                            return (
+                              <div
+                                className="rounded-lg text-xs shadow-lg border px-2.5 py-1.5"
+                                style={{
+                                  backgroundColor: 'var(--bg-elevated)',
+                                  borderColor: 'var(--border-secondary)',
+                                  color: 'var(--text-primary)',
+                                }}
+                              >
+                                <div style={{ color: 'var(--text-muted)' }}>{label}</div>
+                                <div className="font-semibold">{payload[0].value}%</div>
+                              </div>
+                            );
                           }}
-                          itemStyle={{ color: 'var(--text-primary)' }}
-                          labelStyle={{ color: 'var(--text-secondary)', marginBottom: '2px' }}
-                          formatter={(value: number) => [
-                            `${value}%`,
-                            t('activityCalendar.successRateChart'),
-                          ]}
-                          labelFormatter={(label: string) => label}
                         />
                         <Bar
                           dataKey="successRate"

--- a/src/components/study-session/cards/MultipleAnswerCard.tsx
+++ b/src/components/study-session/cards/MultipleAnswerCard.tsx
@@ -11,6 +11,7 @@ import {
   CheckCircle,
   Square,
   CheckSquare,
+  MessageCircle,
 } from 'lucide-react';
 import { CardActionsMenu } from '../menus/CardActionsMenu';
 import { HintOverlay } from '../shared/HintOverlay';
@@ -297,19 +298,18 @@ export const MultipleAnswerCard: React.FC<MultipleAnswerCardProps> = ({
           {/* Back Explanation - shown immediately after answering */}
           {showResult && card.back && (
             <div
-              className="mt-4 p-4 rounded-xl border-2"
+              className="mt-3 px-3 py-2.5 rounded-xl border-2 flex gap-2.5"
               style={{
                 backgroundColor: 'var(--explanation-bg)',
                 borderColor: 'var(--explanation-border)',
               }}
             >
-              <div
-                className="text-sm font-semibold mb-2 uppercase tracking-wide"
+              <MessageCircle
+                size={18}
+                className="flex-shrink-0 mt-0.5"
                 style={{ color: 'var(--explanation-text)' }}
-              >
-                Explicație
-              </div>
-              <p className="font-medium" style={{ color: 'var(--text-primary)' }}>
+              />
+              <p className="text-sm font-medium" style={{ color: 'var(--text-primary)' }}>
                 {card.back}
               </p>
             </div>


### PR DESCRIPTION

Dashboard:
- Bar chart gradient now uses var(--color-accent) instead of hardcoded #22c55e
- Replace Recharts default tooltip with custom content component to eliminate the white/black rectangle overlay (CSS vars don't resolve in Recharts' default contentStyle)
- Restore rounded-md on calendar squares (was incorrectly changed to rounded-sm)

MultipleAnswerCard:
- Replace "EXPLICAȚIE" header text with a MessageCircle icon placed inline to the left of the explanation text
- Reduce vertical space: smaller padding (px-3 py-2.5), no separate header line, text-sm for body

https://claude.ai/code/session_011iJrUFad98kzXZUesAcGEV