### PR TITLE
Fix skipped cards handling in study sessions

### DIFF
--- a/src/components/study-session/StudySessionContainer.tsx
+++ b/src/components/study-session/StudySessionContainer.tsx
@@ -810,6 +810,7 @@ export const StudySessionContainer: React.FC<StudySessionContainerProps> = ({
                 isFirstCard={currentCardIndex === 0}
                 isLastCard={currentCardIndex === (currentSession?.cards?.length || 0) - 1}
                 hasAnswered={answers[currentCard.id] !== undefined}
+                isSkipped={answers[currentCard.id] === 'skipped'}
                 canEditDelete={canEditDelete}
                 onEditCard={handleEditCard}
                 onDeleteCard={handleDeleteCard}

--- a/src/components/study-session/cards/TypeAnswerCard.tsx
+++ b/src/components/study-session/cards/TypeAnswerCard.tsx
@@ -25,6 +25,7 @@ interface TypeAnswerCardProps {
   isFirstCard?: boolean;
   isLastCard?: boolean;
   hasAnswered?: boolean;
+  isSkipped?: boolean;
   canEditDelete?: boolean;
   onEditCard?: () => void;
   onDeleteCard?: () => void;
@@ -45,6 +46,7 @@ export const TypeAnswerCard: React.FC<TypeAnswerCardProps> = ({
   isFirstCard = false,
   isLastCard = false,
   hasAnswered: hasAnsweredProp = false,
+  isSkipped = false,
   canEditDelete = false,
   onEditCard,
   onDeleteCard,
@@ -59,10 +61,10 @@ export const TypeAnswerCard: React.FC<TypeAnswerCardProps> = ({
   const [matchedPitfall, setMatchedPitfall] = React.useState<string | null>(null);
 
   const cardAnswer = answers[card.id];
-  // Show result if card was answered in store
-  const showResult = cardAnswer !== undefined || hasAnswered;
-  // Practice mode: card already answered in store, allow re-trying without XP
-  const isPracticeMode = cardAnswer !== undefined;
+  // Show result if card was definitively answered (correct/incorrect) in store, or just answered locally
+  // Skipped cards should NOT show result — they need to be re-answered
+  const isPracticeMode = cardAnswer === 'correct' || cardAnswer === 'incorrect';
+  const showResult = isPracticeMode || hasAnswered;
 
   // Get correct options for display on back face
   const correctOptions = React.useMemo(() => {
@@ -211,10 +213,11 @@ export const TypeAnswerCard: React.FC<TypeAnswerCardProps> = ({
   };
 
   // Reset state when card changes (fixes navigation bug)
+  // Skipped cards reset to fresh state so the user can properly re-answer them
   React.useEffect(() => {
     setShowBack(false);
     setUserAnswer('');
-    setHasAnswered(hasAnsweredProp);
+    setHasAnswered(isSkipped ? false : hasAnsweredProp);
     setIsCorrect(null);
     setMatchedPitfall(null);
 


### PR DESCRIPTION
## Summary
This PR fixes the handling of skipped cards in study sessions. Previously, skipped cards were treated the same as answered cards, preventing users from re-answering them. Now skipped cards are properly tracked and reset to allow users to answer them on subsequent attempts.

## Key Changes

- **TypeAnswerCard.tsx**: 
  - Added `isSkipped` prop to track when a card has been skipped
  - Updated logic to distinguish between definitively answered cards (`correct`/`incorrect`) and skipped cards
  - Skipped cards now reset to a fresh state instead of showing cached results, allowing users to re-answer them
  - Practice mode now only applies to cards with definitive answers, not skipped cards

- **StudySessionContainer.tsx**:
  - Pass `isSkipped` prop to TypeAnswerCard based on whether the answer value is `'skipped'`

- **studySessionsStore.ts**:
  - Implemented smart card index logic on session load that prioritizes:
    1. First unanswered card
    2. First skipped card (if all cards have some answer)
    3. Full reset if all cards are answered with definitive results
  - Reset streak and sessionXP on load to prevent carrying over progress from previous attempts
  - Clear revealed hints on session load for a fresh start

## Implementation Details
The key insight is that skipped cards should be treated differently from answered cards. A skipped answer (`'skipped'`) indicates the user deferred the card, not that they answered it. This allows the session to intelligently navigate to unanswered cards first, then skipped cards, and only reset everything when all cards have definitive answers.

https://claude.ai/code/session_01LgZcBJWAL1B9ZPwCo8HwCi